### PR TITLE
Cost estimate error format and removed un necessary test cases

### DIFF
--- a/Eligible.NET/Eligible.NET.csproj
+++ b/Eligible.NET/Eligible.NET.csproj
@@ -111,7 +111,7 @@
     <Compile Include="src\EligibleService.Model\Claim\ClaimAcknowledgements.cs" />
     <Compile Include="src\EligibleService.Model\Claim\ClaimResponse.cs" />
     <Compile Include="src\EligibleService.Model\Claim\ClaimClass.cs" />
-    <Compile Include="src\EligibleService.Exceptions\ErrorsStructures\ClaimError.cs" />
+    <Compile Include="src\EligibleService.Exceptions\ErrorsStructures\EligibleGenericError.cs" />
     <Compile Include="src\EligibleService.Model\Claim\Cob.cs" />
     <Compile Include="src\EligibleService.Model\Claim\ContractInformation.cs" />
     <Compile Include="src\EligibleService.Model\Claim\Dependent.cs" />

--- a/Eligible.NET/src/EligibleService.Core/Claim.cs
+++ b/Eligible.NET/src/EligibleService.Core/Claim.cs
@@ -45,9 +45,9 @@ namespace EligibleService.Core
         public ClaimResponse Create(string jsonParams, RequestOptions options = null)
         {
             response = ExecuteObj.ExecutePostPut(EligibleResources.PathToClaims, jsonParams, SetRequestOptionsObject(options));
-            ClaimResponse formattedResponse = RequestProcess.ResponseValidation<ClaimResponse, ClaimErrors>(response);
+            ClaimResponse formattedResponse = RequestProcess.ResponseValidation<ClaimResponse, EligibleGenericError>(response);
             
-            if (formattedResponse.Success == "false")
+            if (formattedResponse.Success == false)
                 throw new EligibleException("Claim creation failed. Please check EligibleError for more details", formattedResponse);
             else
             {
@@ -93,7 +93,7 @@ namespace EligibleService.Core
         public ClaimPaymentReportResponse GetClaimPaymentReport(string referenceId, RequestOptions options = null)
         {
             response = this.GetReport(Path.Combine(EligibleResources.PathToClaims, referenceId, EligibleResources.PaymentReports), options);
-            var formattedResponse = RequestProcess.ResponseValidation<ClaimPaymentReportResponse, ClaimErrors>(response);
+            var formattedResponse = RequestProcess.ResponseValidation<ClaimPaymentReportResponse, EligibleGenericError>(response);
             formattedResponse.SetJsonResponse(response.Content);
             return formattedResponse;
         }
@@ -108,7 +108,7 @@ namespace EligibleService.Core
         public ClaimPaymentReportResponse GetClaimPaymentReport(string referenceId, string id, RequestOptions options = null)
         {
             response = this.GetReport(Path.Combine(EligibleResources.PathToClaims, referenceId, EligibleResources.PaymentReports, id), options);
-            var formattedResponse = RequestProcess.ResponseValidation<ClaimPaymentReportResponse, ClaimErrors>(response);
+            var formattedResponse = RequestProcess.ResponseValidation<ClaimPaymentReportResponse, EligibleGenericError>(response);
             formattedResponse.SetJsonResponse(response.Content);
             return formattedResponse;
         }
@@ -121,7 +121,7 @@ namespace EligibleService.Core
         public ClaimPaymentReportsResponse GetClaimPaymentReport(RequestOptions options = null)
         {
             response = this.GetReport(Path.Combine(EligibleResources.PathToClaims, EligibleResources.PaymentReports), options);
-            var formattedResponse = RequestProcess.ResponseValidation<ClaimPaymentReportsResponse, ClaimErrors>(response);
+            var formattedResponse = RequestProcess.ResponseValidation<ClaimPaymentReportsResponse, EligibleGenericError>(response);
             formattedResponse.SetJsonResponse(response.Content);
             return formattedResponse;
         }

--- a/Eligible.NET/src/EligibleService.Core/CostEstimates.cs
+++ b/Eligible.NET/src/EligibleService.Core/CostEstimates.cs
@@ -19,7 +19,7 @@ namespace EligibleService.Core
         public CostEstimatesResponse Get(Hashtable requiredParams,  RequestOptions options = null)
         {
             response = ExecuteObj.Execute(EligibleResources.CostEstimates, SetRequestOptionsObject(options), requiredParams);
-            var formattedResponse = RequestProcess.ResponseValidation<CostEstimatesResponse, CoverageErrorDetails>(response);
+            var formattedResponse = RequestProcess.ResponseValidation<CostEstimatesResponse, EligibleGenericError>(response);
             formattedResponse.SetJsonResponse(response.Content);
             return formattedResponse;
         }

--- a/Eligible.NET/src/EligibleService.Exceptions/ErrorsStructures/EligibleGenericError.cs
+++ b/Eligible.NET/src/EligibleService.Exceptions/ErrorsStructures/EligibleGenericError.cs
@@ -4,19 +4,19 @@ using System.Collections.ObjectModel;
 
 namespace EligibleService.Exceptions
 {
-    public class ClaimErrors
+    public class EligibleGenericError
     {
         [JsonProperty("success")]
-        public string Success { get; set; }
+        public bool? Success { get; set; }
 
         [JsonProperty("created_at")]
         public DateTime? CreatedAt { get; set; }
 
         [JsonProperty("errors")]
-        public Collection<ClaimError> Errors { get; set; }
+        public Collection<GenericError> Errors { get; set; }
     }
 
-    public class ClaimError : BasicError
+    public class GenericError : BasicError
     {
         [JsonProperty("expected_value")]
         public string ExpectedValue { get; set; }

--- a/Eligible.NET/src/EligibleService.Model/Claim/ClaimAcknowledgements.cs
+++ b/Eligible.NET/src/EligibleService.Model/Claim/ClaimAcknowledgements.cs
@@ -45,7 +45,7 @@ namespace EligibleService.Model
         public string Message { get; set; }
 
         [JsonProperty("errors")]
-        public Collection<EligibleService.Exceptions.ClaimError> Errors { get; set; }
+        public Collection<EligibleService.Exceptions.GenericError> Errors { get; set; }
     }
 
     public class MultipleAcknowledgementsResponse : AcknowledgementCommonProperties

--- a/Eligible.NET/src/EligibleService.Model/Claim/ClaimResponse.cs
+++ b/Eligible.NET/src/EligibleService.Model/Claim/ClaimResponse.cs
@@ -10,7 +10,7 @@ namespace EligibleService.Model
     public class ClaimResponse : JsonResponseClass
     {
         [JsonProperty("success")]
-        public string Success { get; set; }
+        public bool? Success { get; set; }
 
         [JsonProperty("created_at")]
         public DateTime? CreatedAt { get; set; }
@@ -19,6 +19,6 @@ namespace EligibleService.Model
         public string ReferenceId { get; set; }
 
         [JsonProperty("errors")]
-        public Collection<EligibleService.Exceptions.ClaimError> Errors { get; set; }
+        public Collection<EligibleService.Exceptions.GenericError> Errors { get; set; }
     }
 }

--- a/Eligible.NET/src/EligibleService.Model/ClaimReports/Amount.cs
+++ b/Eligible.NET/src/EligibleService.Model/ClaimReports/Amount.cs
@@ -5,7 +5,7 @@ namespace EligibleService.Claim.ClaimReports
     public class Amount : BaseAmount
     {
         [JsonProperty("patient_responsibility")]
-        public int? PatientResponsibility { get; set; }
+        public double? PatientResponsibility { get; set; }
 
         [JsonProperty("prompt_payment_discount")]
         public double? PromptPaymentDiscount { get; set; }

--- a/Eligible.NETTests/Eligible.NETTests.csproj
+++ b/Eligible.NETTests/Eligible.NETTests.csproj
@@ -126,6 +126,7 @@
     <None Include="ExpectedResponse\PayersStatus.json" />
     <None Include="ExpectedResponse\PayersStatussesWithTransactionType.json" />
     <None Include="ExpectedResponse\PayersWithCoverageEndPoint.json" />
+    <None Include="ExpectedResponse\PaymentReports.json" />
     <None Include="ExpectedResponse\PaymentStatus.json" />
     <None Include="ExpectedResponse\ReatimeClaimResponse.json" />
     <None Include="ExpectedResponse\SearchOptionsByPayerId.json" />

--- a/Eligible.NETTests/ExpectedResponse/ClaimPayementReports.json
+++ b/Eligible.NETTests/ExpectedResponse/ClaimPayementReports.json
@@ -1,136 +1,186 @@
 ﻿{
-	"reports": [{
-		"effective_date": "2014-05-08",
-		"payer": {
-			"name": "NATIONAL GOVERNMENT SERVICES #06014",
-			"id": "12M64",
-			"address": {
-				"street_line_1": "P.O.BOX 7064",
-				"street_line_2": null,
-				"city": "INDIANAPOLIS",
-				"state": "IN",
-				"zip": "462077064"
-			},
-			"contacts": [{
-				"department_code": "CX",
-				"department_label": "Payers Claim Office. Location responsible for paying bills related to medical care received",
-				"name": "NATIONAL GOVERNMENT SERVICES, INC. 06014",
-				"details": [{
-					"type_code": "TE",
-					"type_label": "Telephone",
-					"value": "8665906724"
-				}, {
-					"type_code": "FX",
-					"type_label": "Facsimile",
-					"value": "3154424259"
-				}]
+	"effective_date": "2016-01-29",
+	"payer": {
+		"name": "BCBSM",
+		"id": "ELIG_SNDBX",
+		"address": {
+			"street_line_1": "600 E LAFAYETTE",
+			"street_line_2": null,
+			"city": "DETROIT",
+			"state": "MI",
+			"zip": "482260000"
+		},
+		"contacts": [{
+			"department_code": "CX",
+			"department_label": "Payers Claim Office. Location responsible for paying bills related to medical care received",
+			"name": "EDI HELPDESK",
+			"details": [{
+				"type_code": "TE",
+				"type_label": "Telephone",
+				"value": "8005420945"
 			}, {
-				"department_code": "BL",
-				"department_label": "Technical Department",
-				"name": "EDI HELP DESK",
-				"details": [{
-					"type_code": "EM",
-					"type_label": "Electronic Mail",
-					"value": "NGS_EDI_PARTA@WELLPOINT.COM"
-				}, {
-					"type_code": "TE",
-					"type_label": "Telephone",
-					"value": "8772734334"
-				}, {
-					"type_code": "EX",
-					"type_label": "Telephone Extension",
-					"value": "5024232356"
-				}]
-			}],
-			"crossover_payer": {
-				"name": "",
-				"id": ""
-			},
-			"corrected_priority_payer": {
-				"name": "",
-				"id": ""
-			}
-		},
-		"financials": {
-			"type_code": "I",
-			"type_label": "Remittance Information Only",
-			"total_payment_amount": "1320.72",
-			"credit": true,
-			"debit": false,
-			"payment_method_code": "ACH",
-			"payment_method_label": "Automated Clearing House (ACH)",
-			"payment_format_code": "CCP",
-			"payment_format_label": "Cash Concentration/Disbursement plus Addenda (CCD+) (ACH)",
-			"payment_date": "2013-05-09",
-			"payment_trace_number": "EFT123456",
-			"sender": {
-				"dfi_id_qualifier": "01",
-				"dfi_id_qualifier_label": "ABA Transit Routing Number Including Check Digits (9 digits)",
-				"dfi_id": "12345678",
-				"account_number": "00000123456789",
-				"id": "1234567890",
-				"supplemental_code": ""
-			},
-			"receiver": {
-				"dfi_id_qualifier": "01",
-				"dfi_id_qualifier_label": "ABA Transit Routing Number Including Check Digits (9 digits)",
-				"dfi_id": "1234567890",
-				"account_type": "Demand Deposit",
-				"account_number": "1234567890"
-			}
-		},
-		"payee": {
-			"name": "ELIGIBLE INC.",
-			"npi": "1234567890",
-			"address": {
-				"street_line_1": "1842 Union Street",
-				"street_line_2": null,
-				"city": "SAN FRANCISCO",
-				"state": "CA",
-				"zip": "94123"
-			},
-			"additional_ids": [{
-				"type_code": "TJ",
-				"type_label": "Federal Taxpayer's Identification Number",
-				"value": "1234567890"
+				"type_code": "FX",
+				"type_label": "Facsimile",
+				"value": "2484862453"
 			}]
+		}, {
+			"department_code": "BL",
+			"department_label": "Technical Department",
+			"name": "EDI HELPDESK",
+			"details": [{
+				"type_code": "TE",
+				"type_label": "Telephone",
+				"value": "8005420945"
+			}, {
+				"type_code": "FX",
+				"type_label": "Facsimile",
+				"value": "2484862453"
+			}, {
+				"type_code": "EM",
+				"type_label": "Electronic Mail",
+				"value": "EDI@BCBSM.COM"
+			}]
+		}],
+		"crossover_payer": null,
+		"corrected_priority_payer": null
+	},
+	"financials": {
+		"type_code": "I",
+		"type_label": "Remittance Information Only",
+		"total_payment_amount": "1261.03",
+		"credit": true,
+		"debit": false,
+		"payment_method_code": "ACH",
+		"payment_method_label": "Automated Clearing House (ACH)",
+		"payment_format_code": "CCP",
+		"payment_format_label": "Cash Concentration/Disbursement plus Addenda (CCD+) (ACH)",
+		"payment_date": "2016-02-03",
+		"payment_trace_number": "710618145",
+		"sender": {
+			"dfi_id_qualifier": "01",
+			"dfi_id_qualifier_label": "ABA Transit Routing Number Including Check Digits (9 digits)",
+			"dfi_id": "091000019",
+			"account_number": "1382069753",
+			"id": "1382069753",
+			"supplemental_code": ""
 		},
-		"patient": {
-			"first_name": "BENJAMIN",
-			"last_name": "FRANKLIN",
-			"middle_name": "",
-			"id": "123456789"
+		"receiver": {
+			"dfi_id_qualifier": "01",
+			"dfi_id_qualifier_label": "ABA Transit Routing Number Including Check Digits (9 digits)",
+			"dfi_id": "072000096",
+			"account_type": "Demand Deposit",
+			"account_number": "1852205283"
+		}
+	},
+	"payee": {
+		"name": "JENNIFER DESCHRYVER INC",
+		"npi": "1932382397",
+		"address": {
+			"street_line_1": null,
+			"street_line_2": null,
+			"city": "BLOOMFLD HLS",
+			"state": "MI",
+			"zip": "483013068"
 		},
-		"service_provider": {
-			"first_name": "",
-			"last_name": "",
-			"middle_name": "",
-			"npi": ""
+		"additional_ids": [{
+			"type_code": "TJ",
+			"type_label": "Federal Taxpayer's Identification Number",
+			"value": "123123123"
+		}],
+		"adjustments": [],
+		"delivery_method": null
+	},
+	"patient": {
+		"first_name": "*****MIN",
+		"last_name": "*****LIN",
+		"middle_name": "J",
+		"id": "*******890"
+	},
+	"corrected_patient": {
+		"first_name": null,
+		"last_name": null,
+		"middle_name": null,
+		"id": null
+	},
+	"other_patient": {
+		"first_name": null,
+		"last_name": null,
+		"middle_name": null,
+		"id": null
+	},
+	"service_provider": null,
+	"claim": {
+		"control_number": "26160262372500710",
+		"received_date": "2016-01-26",
+		"expiration_date": null,
+		"filing_indicator_type": "12",
+		"filing_indicator_label": "Preferred Provider Organization (PPO)",
+		"place_of_service": "11",
+		"frequency": "1",
+		"responsibility_sequence": "primary",
+		"status": ["processed"],
+		"drg_code": null,
+		"drg_quantity": null,
+		"amount": {
+			"billed": 435.0,
+			"paid": 33.7,
+			"patient_responsibility": 260.0,
+			"total_coverage": 298.68,
+			"prompt_payment_discount": null,
+			"per_day_limit": null,
+			"patient_paid": null,
+			"revised_interest": null,
+			"negative_ledger_balance": null,
+			"tax": null,
+			"total_claim_before_taxes": null,
+			"federal": {
+				"category_1": null,
+				"category_2": null,
+				"category_3": null,
+				"category_4": null,
+				"category_5": null
+			}
 		},
-		"claim": {
-			"control_number": "1234578CDR",
-			"received_date": "2013-05-05",
-			"expiration_date": "2014-06-09",
-			"filing_indicator_type": "MA",
-			"filing_indicator_label": "Medicare Part A",
-			"place_of_service": "32",
-			"frequency": "2",
-			"responsibility_sequence": "primary",
-			"status": [
-				"processed"
-			],
-			"drg_code": "",
-			"drg_quantity": "",
+		"adjustments": [],
+		"quantity": {
+			"actual": {
+				"covered": null,
+				"co_insured": null,
+				"life_time_reserve": null
+			},
+			"estimated": {
+				"life_time_reserve": null,
+				"non_covered": null
+			},
+			"not_replaced_blood_unit": null,
+			"outlier_days": null,
+			"prescription": null,
+			"visits": null,
+			"federal": {
+				"category_1": null,
+				"category_2": null,
+				"category_3": null,
+				"category_4": null,
+				"category_5": null
+			}
+		},
+		"additional_ids": [],
+		"rendering_provider_ids": [],
+		"moa_codes": [],
+		"allowed_amount": 298.68,
+		"contacts": [],
+		"service_lines": [{
+			"procedure_qualifier": "HC<90834",
+			"procedure_code": null,
+			"procedure_modifiers": [],
+			"revenue_code": "",
+			"service_start": "2016-01-05",
+			"service_end": "2016-01-05",
 			"amount": {
-				"billed": 70.0,
-				"paid": 70.0,
-				"patient_responsibility": 0,
-				"total_coverage": null,
-				"prompt_payment_discount": null,
-				"per_day_limit": null,
-				"patient_paid": null,
-				"revised_intrest": null,
-				"negetive_ladger_balance": null,
+				"billed": 145.0,
+				"paid": 0.0,
+				"total_coverage": 99.56,
+				"deduction": null,
 				"tax": null,
 				"total_claim_before_taxes": null,
 				"federal": {
@@ -141,21 +191,9 @@
 					"category_5": null
 				}
 			},
-			"adjustments": [],
 			"quantity": {
-				"actual": {
-					"covered": null,
-					"co_insured": null,
-					"life_time_reserve": null
-				},
-				"estimated": {
-					"life_time_reserve": null,
-					"non_covered": null
-				},
-				"not_replaced_blood_unit": 5,
-				"outlier_days": 14,
-				"prescription": null,
-				"visits": null,
+				"billed": 0.0,
+				"paid": 1.0,
 				"federal": {
 					"category_1": null,
 					"category_2": null,
@@ -164,78 +202,164 @@
 					"category_5": null
 				}
 			},
-			"rendering_provider_ids": [{
-				"id_type": "1C",
-				"id_type_label": "Medicare Provider Number",
-				"id": "12345678"
+			"additional_ids": [],
+			"rendering_provider_ids": [],
+			"allowed_amount": 99.56,
+			"remark_codes": [],
+			"provider_control_number": "123123123",
+			"healthcare_policy": [],
+			"adjustments": [{
+				"type_code": "PR",
+				"type_label": "Patient Responsibility",
+				"reason_code": "1",
+				"reason_label": "Deductible Amount",
+				"amount": 79.56,
+				"quantity": 0.0
 			}, {
-				"id_type": "1D",
-				"id_type_label": "Medicaid Provider Number",
-				"id": "12345678"
-			}],
-			"moa_codes": [
-				"MA01",
-				"MA27",
-				"MA07"
-			],
-			"allowed_amount": 111.12,
-			"service_lines": [{
-				"procedure_qualifier": "HC",
-				"procedure_code": "12345",
-				"procedure_modifiers": [],
-				"revenue_code": "0023",
-				"service_start": "2013-03-19",
-				"service_end": "2013-03-19",
-				"amount": {
-					"billed": 70,
-					"paid": 70,
-					"total_coverage": null,
-					"deduction": null,
-					"tax": null,
-					"total_claim_before_taxes": null,
-					"federal": {
-						"category_1": null,
-						"category_2": null,
-						"category_3": null,
-						"category_4": null,
-						"category_5": null
-					}
-				},
-				"quantity": {
-					"billed": 0,
-					"paid": 1,
-					"federal": {
-						"category_1": null,
-						"category_2": null,
-						"category_3": null,
-						"category_4": null,
-						"category_5": null
-					}
-				},
-				"rendering_provider_ids": [{
-					"id_type": "1C",
-					"id_type_label": "Medicare Provider Number",
-					"id": "12345678"
-				}, {
-					"id_type": "1D",
-					"id_type_label": "Medicaid Provider Number",
-					"id": "12345678"
-				}],
-				"allowed_amount": 111.12,
-				"adjustments": [{
-					"type_code": "CO",
-					"type_label": "Contractual Obligations",
-					"reason_code": "97",
-					"reason_label": "The benefit for this service is included in the payment/allowance for another service/procedure that has already been adjudicated. Note: Refer to the 835 Healthcare Policy Identification Segment (loop 2110 Service Payment Information REF), if present.",
-					"amount": -1320.72,
-					"quantity": 0
-				}]
+				"type_code": "PR",
+				"type_label": "Patient Responsibility",
+				"reason_code": "3",
+				"reason_label": "Co-payment Amount",
+				"amount": 20.0,
+				"quantity": 0.0
+			}, {
+				"type_code": "CO",
+				"type_label": "Contractual Obligations",
+				"reason_code": "45",
+				"reason_label": "Charge exceeds fee schedule/maximum allowable or contracted/legislated fee arrangement. (Use only with Group Codes PR or CO depending upon liability)",
+				"amount": 45.44,
+				"quantity": 0.0
 			}]
-		},
-		"reference_id": "BDA85HY09IJ"
-	}],
-	"page": 1,
-	"per_page": 30,
-	"num_of_pages": 1,
-	"total": 1
+		}, {
+			"procedure_qualifier": "HC<90834",
+			"procedure_code": null,
+			"procedure_modifiers": [],
+			"revenue_code": "",
+			"service_start": "2016-01-11",
+			"service_end": "2016-01-11",
+			"amount": {
+				"billed": 145.0,
+				"paid": 0.0,
+				"total_coverage": 99.56,
+				"deduction": null,
+				"tax": null,
+				"total_claim_before_taxes": null,
+				"federal": {
+					"category_1": null,
+					"category_2": null,
+					"category_3": null,
+					"category_4": null,
+					"category_5": null
+				}
+			},
+			"quantity": {
+				"billed": 0.0,
+				"paid": 1.0,
+				"federal": {
+					"category_1": null,
+					"category_2": null,
+					"category_3": null,
+					"category_4": null,
+					"category_5": null
+				}
+			},
+			"additional_ids": [],
+			"rendering_provider_ids": [],
+			"allowed_amount": 99.56,
+			"remark_codes": [],
+			"provider_control_number": "123123123",
+			"healthcare_policy": [],
+			"adjustments": [{
+				"type_code": "PR",
+				"type_label": "Patient Responsibility",
+				"reason_code": "1",
+				"reason_label": "Deductible Amount",
+				"amount": 79.56,
+				"quantity": 0.0
+			}, {
+				"type_code": "PR",
+				"type_label": "Patient Responsibility",
+				"reason_code": "3",
+				"reason_label": "Co-payment Amount",
+				"amount": 20.0,
+				"quantity": 0.0
+			}, {
+				"type_code": "CO",
+				"type_label": "Contractual Obligations",
+				"reason_code": "45",
+				"reason_label": "Charge exceeds fee schedule/maximum allowable or contracted/legislated fee arrangement. (Use only with Group Codes PR or CO depending upon liability)",
+				"amount": 45.44,
+				"quantity": 0.0
+			}]
+		}, {
+			"procedure_qualifier": "HC<90834",
+			"procedure_code": null,
+			"procedure_modifiers": [],
+			"revenue_code": "",
+			"service_start": "2016-01-25",
+			"service_end": "2016-01-25",
+			"amount": {
+				"billed": 145.0,
+				"paid": 33.7,
+				"total_coverage": 99.56,
+				"deduction": null,
+				"tax": null,
+				"total_claim_before_taxes": null,
+				"federal": {
+					"category_1": null,
+					"category_2": null,
+					"category_3": null,
+					"category_4": null,
+					"category_5": null
+				}
+			},
+			"quantity": {
+				"billed": 0.0,
+				"paid": 1.0,
+				"federal": {
+					"category_1": null,
+					"category_2": null,
+					"category_3": null,
+					"category_4": null,
+					"category_5": null
+				}
+			},
+			"additional_ids": [],
+			"rendering_provider_ids": [],
+			"allowed_amount": 99.56,
+			"remark_codes": [],
+			"provider_control_number": "123123123",
+			"healthcare_policy": [],
+			"adjustments": [{
+				"type_code": "PR",
+				"type_label": "Patient Responsibility",
+				"reason_code": "1",
+				"reason_label": "Deductible Amount",
+				"amount": 40.88,
+				"quantity": 0.0
+			}, {
+				"type_code": "PR",
+				"type_label": "Patient Responsibility",
+				"reason_code": "3",
+				"reason_label": "Co-payment Amount",
+				"amount": 20.0,
+				"quantity": 0.0
+			}, {
+				"type_code": "CO",
+				"type_label": "Contractual Obligations",
+				"reason_code": "144",
+				"reason_label": "Incentive adjustment, e.g. preferred product/service.",
+				"amount": 4.98,
+				"quantity": 0.0
+			}, {
+				"type_code": "CO",
+				"type_label": "Contractual Obligations",
+				"reason_code": "45",
+				"reason_label": "Charge exceeds fee schedule/maximum allowable or contracted/legislated fee arrangement. (Use only with Group Codes PR or CO depending upon liability)",
+				"amount": 45.44,
+				"quantity": 0.0
+			}]
+		}]
+	},
+	"reference_id": "8IZ9JZI2FUEDCS"
 }

--- a/Eligible.NETTests/ExpectedResponse/ClaimPaymentReport.json
+++ b/Eligible.NETTests/ExpectedResponse/ClaimPaymentReport.json
@@ -1,281 +1,366 @@
 ﻿{
-    "reference_id": "31WIGIZLVDAIL",
-    "effective_date": "2013-05-13",
-    "payer": {
-        "name": "BLUE CROSS AND BLUE SHIELD OF LA",
-        "id": "LABLS",
-        "address": {
-            "street_line_1": "P O BOX 98029",
-            "street_line_2": null,
-            "city": "BATON ROUGE",
-            "state": "LA",
-            "zip": "70898"
-        },
-        "contacts": [
-            {
-                "department_code": "CX",
-                "department_label": "Payers Claim Office. Location responsible for paying bills related to medical care received",
-                "name": "EDI Clearing House",
-                "details": [
-                    {
-                        "type_code": "EM",
-                        "type_label": "Electronic Mail",
-                        "value": "edich@bcbsla.com"
-                    },
-                    {
-                        "type_code": "TE",
-                        "type_label": "Telephone",
-                        "value": "2252914334"
-                    }
-                ]
-            },
-            {
-                "department_code": "BL",
-                "department_label": "Technical Department",
-                "name": "EDI Clearing House",
-                "details": [
-                    {
-                        "type_code": "EM",
-                        "type_label": "Electronic Mail",
-                        "value": "edich@bcbsla.com"
-                    },
-                    {
-                        "type_code": "TE",
-                        "type_label": "Telephone",
-                        "value": "2252914334"
-                    }
-                ]
-            }
-        ],
-        "crossover_payer": {
-            "name": "",
-            "id": ""
-        },
-        "corrected_priority_payer": {
-            "name": "",
-            "id": ""
-        }
-    },
-    "financials": {
-        "type_code": "I",
-        "type_label": "Remittance Information Only",
-        "total_payment_amount": "123",
-        "credit": true,
-        "debit": false,
-        "payment_method_code": "ACH",
-        "payment_method_label": "Automated Clearing House (ACH)",
-        "payment_format_code": "CCP",
-        "payment_format_label": "Cash Concentration/Disbursement plus Addenda (CCD+) (ACH)",
-        "payment_date": "2013-05-21",
-        "payment_trace_number": "12345",
-        "sender": {
-            "dfi_id_qualifier": "01",
-            "dfi_id_qualifier_label": "ABA Transit Routing Number Including Check Digits (9 digits)",
-            "dfi_id": "065000171",
-            "account_number": "0716784580",
-            "id": "1237384555",
-            "supplemental_code": ""
-        },
-        "receiver": {
-            "dfi_id_qualifier": "01",
-            "dfi_id_qualifier_label": "ABA Transit Routing Number Including Check Digits (9 digits)",
-            "dfi_id": "1234568",
-            "account_type": "Demand Deposit",
-            "account_number": "123456789"
-        }
-    },
-    "payee": {
-        "name": "Eligible Inc.",
-        "npi": "1234567890",
-        "address": {
-            "street_line_1": "1842 Union Street",
-            "street_line_2": "",
-            "city": "SAN FRANCISCO",
-            "state": "CA",
-            "zip": "94123"
-        },
-        "additional_ids": [
-            {
-                "type_code": "TJ",
-                "type_label": "Federal Taxpayer's Identification Number",
-                "value": "1234567890"
-            },
-            {
-                "type_code": "PQ",
-                "type_label": "Payee Identification",
-                "value": "12345456"
-            }
-        ],
-        "adjustments": [],
-        "delivery_method": null
-    },
-    "patient": {
-        "first_name": "BENJAMIN",
-        "last_name": "FRANKLIN",
-        "middle_name": "",
-        "id": "XXXXX12345"
-    },
-    "corrected_patient": {
-        "first_name": null,
-        "last_name": null,
-        "middle_name": null,
-        "id": null
-    },
-    "other_patient": {
-        "first_name": null,
-        "last_name": null,
-        "middle_name": null,
-        "id": null
-    },
-    "service_provider": {
-        "first_name": "",
-        "last_name": "",
-        "middle_name": "",
-        "npi": ""
-    },
-    "claim": {
-        "control_number": "140852092800",
-        "received_date": "2013-05-09",
-        "expiration_date": "2014-06-09",
-        "filing_indicator_type": "12",
-        "filing_indicator_label": "Preferred Provider Organization (PPO)",
-        "place_of_service": "15",
-        "frequency": "1",
-        "responsibility_sequence": "primary",
-        "status": [
-            "processed"
-        ],
-        "drg_code": "",
-        "drg_quantity": "",
-        "amount": {
-            "billed": 70.0,
-            "paid": 70.0,
-            "patient_responsibility": 0,
-            "total_coverage": null,
-            "prompt_payment_discount": null,
-            "per_day_limit": null,
-            "patient_paid": null,
-            "revised_intrest": null,
-            "negetive_ladger_balance": null,
-            "tax": null,
-            "total_claim_before_taxes": null,
-            "federal": {
-                "category_1": null,
-                "category_2": null,
-                "category_3": null,
-                "category_4": null,
-                "category_5": null
-            }
-        },
-        "adjustments": [],
-        "quantity": {
-            "actual": {
-                "covered": null,
-                "co_insured": null,
-                "life_time_reserve": null
-            },
-            "estimated": {
-                "life_time_reserve": null,
-                "non_covered": null
-            },
-            "not_replaced_blood_unit": 5,
-            "outlier_days": 14,
-            "prescription": null,
-            "visits": null,
-            "federal": {
-                "category_1": null,
-                "category_2": null,
-                "category_3": null,
-                "category_4": null,
-                "category_5": null
-            }
-        },
-        "additional_ids": [
-            {
-                "type_code": "1L",
-                "type_label": "Group or Policy Number",
-                "value": "000P086210000"
-            },
-            {
-                "type_code": "CE",
-                "type_label": "Class of Contract Code",
-                "value": "PREFERRED PROVIDER ORGANIZATION"
-            }
-        ],
-        "rendering_provider_ids": [
-            {
-                "type_code": "1C",
-                "type_label": "Medicare Provider Number",
-                "value": "12345678"
-            },
-            {
-                "type_code": "1D",
-                "type_label": "Medicaid Provider Number",
-                "value": "12345678"
-            }
-        ],
-        "moa_codes": [
-            "MA01",
-            "MA27",
-            "MA07"
-        ],
-        "allowed_amount": 111.12,
-        "contacts": [],
-        "service_lines": [
-            {
-                "procedure_qualifier": "HC",
-                "procedure_code": "12345",
-                "procedure_modifiers": [
-                    "U1"
-                ],
-                "revenue_code": "",
-                "service_start": "2013-02-13",
-                "service_end": "2013-02-13",
-                "amount": {
-                    "billed": 70.0,
-                    "paid": 70.0,
-                    "total_coverage": null,
-                    "deduction": null,
-                    "tax": null,
-                    "total_claim_before_taxes": null,
-                    "federal": {
-                        "category_1": null,
-                        "category_2": null,
-                        "category_3": null,
-                        "category_4": null,
-                        "category_5": null
-                    }
-                },
-                "quantity": {
-                    "billed": 1.0,
-                    "paid": 1.0,
-                    "federal": {
-                        "category_1": null,
-                        "category_2": null,
-                        "category_3": null,
-                        "category_4": null,
-                        "category_5": null
-                    }
-                },
-                "rendering_provider_ids": [
-                    {
-                        "type_code": "1C",
-                        "type_label": "Medicare Provider Number",
-                        "value": "12345678"
-                    },
-                    {
-                        "type_code": "1D",
-                        "type_label": "Medicaid Provider Number",
-                        "value": "12345678"
-                    }
-                ],
-                "allowed_amount": 111.12,
-                "additional_ids": [],
-                "remark_codes": [],
-                "provider_control_number": "37928",
-                "healthcare_policy": [],
-                "adjustments": []
-            }
-        ]
-    }
+	"effective_date": "2016-01-29",
+	"payer": {
+		"name": "BCBSM",
+		"id": "ELIG_SNDBX",
+		"address": {
+			"street_line_1": "600 E LAFAYETTE",
+			"street_line_2": null,
+			"city": "DETROIT",
+			"state": "MI",
+			"zip": "482260000"
+		},
+		"contacts": [{
+			"department_code": "CX",
+			"department_label": "Payers Claim Office. Location responsible for paying bills related to medical care received",
+			"name": "EDI HELPDESK",
+			"details": [{
+				"type_code": "TE",
+				"type_label": "Telephone",
+				"value": "8005420945"
+			}, {
+				"type_code": "FX",
+				"type_label": "Facsimile",
+				"value": "2484862453"
+			}]
+		}, {
+			"department_code": "BL",
+			"department_label": "Technical Department",
+			"name": "EDI HELPDESK",
+			"details": [{
+				"type_code": "TE",
+				"type_label": "Telephone",
+				"value": "8005420945"
+			}, {
+				"type_code": "FX",
+				"type_label": "Facsimile",
+				"value": "2484862453"
+			}, {
+				"type_code": "EM",
+				"type_label": "Electronic Mail",
+				"value": "EDI@BCBSM.COM"
+			}]
+		}],
+		"crossover_payer": null,
+		"corrected_priority_payer": null
+	},
+	"financials": {
+		"type_code": "I",
+		"type_label": "Remittance Information Only",
+		"total_payment_amount": "1261.03",
+		"credit": true,
+		"debit": false,
+		"payment_method_code": "ACH",
+		"payment_method_label": "Automated Clearing House (ACH)",
+		"payment_format_code": "CCP",
+		"payment_format_label": "Cash Concentration/Disbursement plus Addenda (CCD+) (ACH)",
+		"payment_date": "2016-02-03",
+		"payment_trace_number": "710618145",
+		"sender": {
+			"dfi_id_qualifier": "01",
+			"dfi_id_qualifier_label": "ABA Transit Routing Number Including Check Digits (9 digits)",
+			"dfi_id": "091000019",
+			"account_number": "1382069753",
+			"id": "1382069753",
+			"supplemental_code": ""
+		},
+		"receiver": {
+			"dfi_id_qualifier": "01",
+			"dfi_id_qualifier_label": "ABA Transit Routing Number Including Check Digits (9 digits)",
+			"dfi_id": "072000096",
+			"account_type": "Demand Deposit",
+			"account_number": "1852205283"
+		}
+	},
+	"payee": {
+		"name": "JENNIFER DESCHRYVER INC",
+		"npi": "1932382397",
+		"address": {
+			"street_line_1": null,
+			"street_line_2": null,
+			"city": "BLOOMFLD HLS",
+			"state": "MI",
+			"zip": "483013068"
+		},
+		"additional_ids": [{
+			"type_code": "TJ",
+			"type_label": "Federal Taxpayer's Identification Number",
+			"value": "123123123"
+		}],
+		"adjustments": [],
+		"delivery_method": null
+	},
+	"patient": {
+		"first_name": "*****MIN",
+		"last_name": "*****LIN",
+		"middle_name": "J",
+		"id": "*******890"
+	},
+	"corrected_patient": {
+		"first_name": null,
+		"last_name": null,
+		"middle_name": null,
+		"id": null
+	},
+	"other_patient": {
+		"first_name": null,
+		"last_name": null,
+		"middle_name": null,
+		"id": null
+	},
+	"service_provider": null,
+	"claim": {
+		"control_number": "26160262372500710",
+		"received_date": "2016-01-26",
+		"expiration_date": null,
+		"filing_indicator_type": "12",
+		"filing_indicator_label": "Preferred Provider Organization (PPO)",
+		"place_of_service": "11",
+		"frequency": "1",
+		"responsibility_sequence": "primary",
+		"status": ["processed"],
+		"drg_code": null,
+		"drg_quantity": null,
+		"amount": {
+			"billed": 435.0,
+			"paid": 33.7,
+			"patient_responsibility": 260.0,
+			"total_coverage": 298.68,
+			"prompt_payment_discount": null,
+			"per_day_limit": null,
+			"patient_paid": null,
+			"revised_interest": null,
+			"negative_ledger_balance": null,
+			"tax": null,
+			"total_claim_before_taxes": null,
+			"federal": {
+				"category_1": null,
+				"category_2": null,
+				"category_3": null,
+				"category_4": null,
+				"category_5": null
+			}
+		},
+		"adjustments": [],
+		"quantity": {
+			"actual": {
+				"covered": null,
+				"co_insured": null,
+				"life_time_reserve": null
+			},
+			"estimated": {
+				"life_time_reserve": null,
+				"non_covered": null
+			},
+			"not_replaced_blood_unit": null,
+			"outlier_days": null,
+			"prescription": null,
+			"visits": null,
+			"federal": {
+				"category_1": null,
+				"category_2": null,
+				"category_3": null,
+				"category_4": null,
+				"category_5": null
+			}
+		},
+		"additional_ids": [],
+		"rendering_provider_ids": [],
+		"moa_codes": [],
+		"allowed_amount": 298.68,
+		"contacts": [],
+		"service_lines": [{
+			"procedure_qualifier": "HC<90834",
+			"procedure_code": null,
+			"procedure_modifiers": [],
+			"revenue_code": "",
+			"service_start": "2016-01-05",
+			"service_end": "2016-01-05",
+			"amount": {
+				"billed": 145.0,
+				"paid": 0.0,
+				"total_coverage": 99.56,
+				"deduction": null,
+				"tax": null,
+				"total_claim_before_taxes": null,
+				"federal": {
+					"category_1": null,
+					"category_2": null,
+					"category_3": null,
+					"category_4": null,
+					"category_5": null
+				}
+			},
+			"quantity": {
+				"billed": 0.0,
+				"paid": 1.0,
+				"federal": {
+					"category_1": null,
+					"category_2": null,
+					"category_3": null,
+					"category_4": null,
+					"category_5": null
+				}
+			},
+			"additional_ids": [],
+			"rendering_provider_ids": [],
+			"allowed_amount": 99.56,
+			"remark_codes": [],
+			"provider_control_number": "123123123",
+			"healthcare_policy": [],
+			"adjustments": [{
+				"type_code": "PR",
+				"type_label": "Patient Responsibility",
+				"reason_code": "1",
+				"reason_label": "Deductible Amount",
+				"amount": 79.56,
+				"quantity": 0.0
+			}, {
+				"type_code": "PR",
+				"type_label": "Patient Responsibility",
+				"reason_code": "3",
+				"reason_label": "Co-payment Amount",
+				"amount": 20.0,
+				"quantity": 0.0
+			}, {
+				"type_code": "CO",
+				"type_label": "Contractual Obligations",
+				"reason_code": "45",
+				"reason_label": "Charge exceeds fee schedule/maximum allowable or contracted/legislated fee arrangement. (Use only with Group Codes PR or CO depending upon liability)",
+				"amount": 45.44,
+				"quantity": 0.0
+			}]
+		}, {
+			"procedure_qualifier": "HC<90834",
+			"procedure_code": null,
+			"procedure_modifiers": [],
+			"revenue_code": "",
+			"service_start": "2016-01-11",
+			"service_end": "2016-01-11",
+			"amount": {
+				"billed": 145.0,
+				"paid": 0.0,
+				"total_coverage": 99.56,
+				"deduction": null,
+				"tax": null,
+				"total_claim_before_taxes": null,
+				"federal": {
+					"category_1": null,
+					"category_2": null,
+					"category_3": null,
+					"category_4": null,
+					"category_5": null
+				}
+			},
+			"quantity": {
+				"billed": 0.0,
+				"paid": 1.0,
+				"federal": {
+					"category_1": null,
+					"category_2": null,
+					"category_3": null,
+					"category_4": null,
+					"category_5": null
+				}
+			},
+			"additional_ids": [],
+			"rendering_provider_ids": [],
+			"allowed_amount": 99.56,
+			"remark_codes": [],
+			"provider_control_number": "123123123",
+			"healthcare_policy": [],
+			"adjustments": [{
+				"type_code": "PR",
+				"type_label": "Patient Responsibility",
+				"reason_code": "1",
+				"reason_label": "Deductible Amount",
+				"amount": 79.56,
+				"quantity": 0.0
+			}, {
+				"type_code": "PR",
+				"type_label": "Patient Responsibility",
+				"reason_code": "3",
+				"reason_label": "Co-payment Amount",
+				"amount": 20.0,
+				"quantity": 0.0
+			}, {
+				"type_code": "CO",
+				"type_label": "Contractual Obligations",
+				"reason_code": "45",
+				"reason_label": "Charge exceeds fee schedule/maximum allowable or contracted/legislated fee arrangement. (Use only with Group Codes PR or CO depending upon liability)",
+				"amount": 45.44,
+				"quantity": 0.0
+			}]
+		}, {
+			"procedure_qualifier": "HC<90834",
+			"procedure_code": null,
+			"procedure_modifiers": [],
+			"revenue_code": "",
+			"service_start": "2016-01-25",
+			"service_end": "2016-01-25",
+			"amount": {
+				"billed": 145.0,
+				"paid": 33.7,
+				"total_coverage": 99.56,
+				"deduction": null,
+				"tax": null,
+				"total_claim_before_taxes": null,
+				"federal": {
+					"category_1": null,
+					"category_2": null,
+					"category_3": null,
+					"category_4": null,
+					"category_5": null
+				}
+			},
+			"quantity": {
+				"billed": 0.0,
+				"paid": 1.0,
+				"federal": {
+					"category_1": null,
+					"category_2": null,
+					"category_3": null,
+					"category_4": null,
+					"category_5": null
+				}
+			},
+			"additional_ids": [],
+			"rendering_provider_ids": [],
+			"allowed_amount": 99.56,
+			"remark_codes": [],
+			"provider_control_number": "123123123",
+			"healthcare_policy": [],
+			"adjustments": [{
+				"type_code": "PR",
+				"type_label": "Patient Responsibility",
+				"reason_code": "1",
+				"reason_label": "Deductible Amount",
+				"amount": 40.88,
+				"quantity": 0.0
+			}, {
+				"type_code": "PR",
+				"type_label": "Patient Responsibility",
+				"reason_code": "3",
+				"reason_label": "Co-payment Amount",
+				"amount": 20.0,
+				"quantity": 0.0
+			}, {
+				"type_code": "CO",
+				"type_label": "Contractual Obligations",
+				"reason_code": "144",
+				"reason_label": "Incentive adjustment, e.g. preferred product/service.",
+				"amount": 4.98,
+				"quantity": 0.0
+			}, {
+				"type_code": "CO",
+				"type_label": "Contractual Obligations",
+				"reason_code": "45",
+				"reason_label": "Charge exceeds fee schedule/maximum allowable or contracted/legislated fee arrangement. (Use only with Group Codes PR or CO depending upon liability)",
+				"amount": 45.44,
+				"quantity": 0.0
+			}]
+		}]
+	},
+	"reference_id": "8IZ9JZI2FUEDCS",
+	"id": "UP4OCS4PUY455"
 }

--- a/Eligible.NETTests/ExpectedResponse/ClaimSuccess.json
+++ b/Eligible.NETTests/ExpectedResponse/ClaimSuccess.json
@@ -1,5 +1,5 @@
 ﻿{
-	"success": "true",
+	"success": true,
 	"created_at": "2015-12-09T14:23:17Z",
 	"reference_id": "12121212"
 }

--- a/Eligible.NETTests/ExpectedResponse/CostEstimates.json
+++ b/Eligible.NETTests/ExpectedResponse/CostEstimates.json
@@ -1,6 +1,6 @@
 ﻿{
-	"created_at": "2016-02-27T09:50:59-05:00",
-	"eligible_id": "UQN7KVMTZUB2K",
+	"created_at": "2016-04-15T13:29:05Z",
+	"eligible_id": "UTSI8NXZLZHV4",
 	"known_issues": [],
 	"demographics": {
 		"subscriber": {
@@ -311,10 +311,7 @@
 						"quantity": null,
 						"contact_details": [],
 						"dates": [],
-						"comments": [],
-						"copayment": true,
-						"coinsurance": true,
-						"deductible": true
+						"comments": []
 					}, {
 						"amount": "6000",
 						"level": "FAMILY",
@@ -329,7 +326,10 @@
 						"quantity": null,
 						"contact_details": [],
 						"dates": [],
-						"comments": []
+						"comments": [],
+						"copayment": true,
+						"coinsurance": true,
+						"deductible": true
 					}],
 					"out_network": [{
 						"amount": "7250",
@@ -896,8 +896,8 @@
 	"cost_estimates": [{
 		"cost_estimate_equation": {
 			"deductible": [{
-				"amount": "1000",
-				"level": "INDIVIDUAL",
+				"amount": "3000",
+				"level": "FAMILY",
 				"insurance_type": null,
 				"insurance_type_label": null,
 				"pos": null,
@@ -914,8 +914,8 @@
 			"coinsurance": [],
 			"copayment": [],
 			"stop_loss": [{
-				"amount": "2500",
-				"level": "INDIVIDUAL",
+				"amount": "6000",
+				"level": "FAMILY",
 				"insurance_type": null,
 				"insurance_type_label": null,
 				"pos": null,
@@ -935,8 +935,8 @@
 		},
 		"cost_estimate_alternatives": {
 			"deductible": [{
-				"amount": "1000",
-				"level": "INDIVIDUAL",
+				"amount": "3000",
+				"level": "FAMILY",
 				"insurance_type": null,
 				"insurance_type_label": null,
 				"pos": null,
@@ -953,8 +953,8 @@
 			"coinsurance": [],
 			"copayment": [],
 			"stop_loss": [{
-				"amount": "2500",
-				"level": "INDIVIDUAL",
+				"amount": "6000",
+				"level": "FAMILY",
 				"insurance_type": null,
 				"insurance_type_label": null,
 				"pos": null,
@@ -972,7 +972,8 @@
 				"deductible": true
 			}]
 		},
-		"cost_estimate": 1000.0,
-		"provider_price": 1500.5
-	}]
+		"provider_price": 1500.5,
+		"cost_estimate": 1500.5
+	}],
+	"success": true
 }

--- a/Eligible.NETTests/ExpectedResponse/PaymentReports.json
+++ b/Eligible.NETTests/ExpectedResponse/PaymentReports.json
@@ -1,0 +1,11888 @@
+﻿{
+  "reports": [
+    {
+      "effective_date": "2016-04-15",
+      "payer": {
+        "name": "BCBSM",
+        "id": "ELIG_SNDBX",
+        "address": {
+          "street_line_1": "600 E LAFAYETTE",
+          "street_line_2": null,
+          "city": "DETROIT",
+          "state": "MI",
+          "zip": "482260000"
+        },
+        "contacts": [
+          {
+            "department_code": "CX",
+            "department_label": "Payers Claim Office. Location responsible for paying bills related to medical care received",
+            "name": "EDI HELPDESK",
+            "details": [
+              {
+                "type_code": "TE",
+                "type_label": "Telephone",
+                "value": "8005420945"
+              },
+              {
+                "type_code": "FX",
+                "type_label": "Facsimile",
+                "value": "2484862453"
+              }
+            ]
+          },
+          {
+            "department_code": "BL",
+            "department_label": "Technical Department",
+            "name": "EDI HELPDESK",
+            "details": [
+              {
+                "type_code": "TE",
+                "type_label": "Telephone",
+                "value": "8005420945"
+              },
+              {
+                "type_code": "FX",
+                "type_label": "Facsimile",
+                "value": "2484862453"
+              },
+              {
+                "type_code": "EM",
+                "type_label": "Electronic Mail",
+                "value": "EDI@BCBSM.COM"
+              }
+            ]
+          }
+        ],
+        "crossover_payer": null,
+        "corrected_priority_payer": null
+      },
+      "financials": {
+        "type_code": "I",
+        "type_label": "Remittance Information Only",
+        "total_payment_amount": "1261.03",
+        "credit": true,
+        "debit": false,
+        "payment_method_code": "ACH",
+        "payment_method_label": "Automated Clearing House (ACH)",
+        "payment_format_code": "CCP",
+        "payment_format_label": "Cash Concentration/Disbursement plus Addenda (CCD+) (ACH)",
+        "payment_date": "2016-02-03",
+        "payment_trace_number": "710618145",
+        "sender": {
+          "dfi_id_qualifier": "01",
+          "dfi_id_qualifier_label": "ABA Transit Routing Number Including Check Digits (9 digits)",
+          "dfi_id": "091000019",
+          "account_number": "1382069753",
+          "id": "1382069753",
+          "supplemental_code": ""
+        },
+        "receiver": {
+          "dfi_id_qualifier": "01",
+          "dfi_id_qualifier_label": "ABA Transit Routing Number Including Check Digits (9 digits)",
+          "dfi_id": "072000096",
+          "account_type": "Demand Deposit",
+          "account_number": "1852205283"
+        }
+      },
+      "payee": {
+        "name": "JENNIFER DESCHRYVER INC",
+        "npi": "1932382397",
+        "address": {
+          "street_line_1": null,
+          "street_line_2": null,
+          "city": "BLOOMFLD HLS",
+          "state": "MI",
+          "zip": "483013068"
+        },
+        "additional_ids": [
+          {
+            "type_code": "TJ",
+            "type_label": "Federal Taxpayer's Identification Number",
+            "value": "123123123"
+          }
+        ],
+        "adjustments": [],
+        "delivery_method": null
+      },
+      "patient": {
+        "first_name": "*****MIN",
+        "last_name": "*****LIN",
+        "middle_name": "J",
+        "id": "*******890"
+      },
+      "corrected_patient": {
+        "first_name": null,
+        "last_name": null,
+        "middle_name": null,
+        "id": null
+      },
+      "other_patient": {
+        "first_name": null,
+        "last_name": null,
+        "middle_name": null,
+        "id": null
+      },
+      "service_provider": null,
+      "claim": {
+        "control_number": "26160262372500710",
+        "received_date": "2016-04-15",
+        "expiration_date": null,
+        "filing_indicator_type": "12",
+        "filing_indicator_label": "Preferred Provider Organization (PPO)",
+        "place_of_service": "11",
+        "frequency": "1",
+        "responsibility_sequence": "primary",
+        "status": [
+          "processed"
+        ],
+        "drg_code": null,
+        "drg_quantity": null,
+        "amount": {
+          "billed": 435,
+          "paid": 33.7,
+          "patient_responsibility": 260,
+          "total_coverage": 298.68,
+          "prompt_payment_discount": null,
+          "per_day_limit": null,
+          "patient_paid": null,
+          "revised_interest": null,
+          "negative_ledger_balance": null,
+          "tax": null,
+          "total_claim_before_taxes": null,
+          "federal": {
+            "category_1": null,
+            "category_2": null,
+            "category_3": null,
+            "category_4": null,
+            "category_5": null
+          }
+        },
+        "adjustments": [],
+        "quantity": {
+          "actual": {
+            "covered": null,
+            "co_insured": null,
+            "life_time_reserve": null
+          },
+          "estimated": {
+            "life_time_reserve": null,
+            "non_covered": null
+          },
+          "not_replaced_blood_unit": null,
+          "outlier_days": null,
+          "prescription": null,
+          "visits": null,
+          "federal": {
+            "category_1": null,
+            "category_2": null,
+            "category_3": null,
+            "category_4": null,
+            "category_5": null
+          }
+        },
+        "additional_ids": [],
+        "rendering_provider_ids": [],
+        "moa_codes": [],
+        "allowed_amount": 298.68,
+        "contacts": [],
+        "service_lines": [
+          {
+            "procedure_qualifier": "HC<90834",
+            "procedure_code": null,
+            "procedure_modifiers": [],
+            "revenue_code": "",
+            "service_start": "2016-04-15",
+            "service_end": "2016-04-15",
+            "amount": {
+              "billed": 145,
+              "paid": 0,
+              "total_coverage": 99.56,
+              "deduction": null,
+              "tax": null,
+              "total_claim_before_taxes": null,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "quantity": {
+              "billed": 0,
+              "paid": 1,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "additional_ids": [],
+            "rendering_provider_ids": [],
+            "allowed_amount": 99.56,
+            "remark_codes": [],
+            "provider_control_number": "123123123",
+            "healthcare_policy": [],
+            "adjustments": [
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "1",
+                "reason_label": "Deductible Amount",
+                "amount": 79.56,
+                "quantity": 0
+              },
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "3",
+                "reason_label": "Co-payment Amount",
+                "amount": 20,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "45",
+                "reason_label": "Charge exceeds fee schedule/maximum allowable or contracted/legislated fee arrangement. (Use only with Group Codes PR or CO depending upon liability)",
+                "amount": 45.44,
+                "quantity": 0
+              }
+            ]
+          },
+          {
+            "procedure_qualifier": "HC<90834",
+            "procedure_code": null,
+            "procedure_modifiers": [],
+            "revenue_code": "",
+            "service_start": "2016-04-15",
+            "service_end": "2016-04-15",
+            "amount": {
+              "billed": 145,
+              "paid": 0,
+              "total_coverage": 99.56,
+              "deduction": null,
+              "tax": null,
+              "total_claim_before_taxes": null,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "quantity": {
+              "billed": 0,
+              "paid": 1,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "additional_ids": [],
+            "rendering_provider_ids": [],
+            "allowed_amount": 99.56,
+            "remark_codes": [],
+            "provider_control_number": "123123123",
+            "healthcare_policy": [],
+            "adjustments": [
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "1",
+                "reason_label": "Deductible Amount",
+                "amount": 79.56,
+                "quantity": 0
+              },
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "3",
+                "reason_label": "Co-payment Amount",
+                "amount": 20,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "45",
+                "reason_label": "Charge exceeds fee schedule/maximum allowable or contracted/legislated fee arrangement. (Use only with Group Codes PR or CO depending upon liability)",
+                "amount": 45.44,
+                "quantity": 0
+              }
+            ]
+          },
+          {
+            "procedure_qualifier": "HC<90834",
+            "procedure_code": null,
+            "procedure_modifiers": [],
+            "revenue_code": "",
+            "service_start": "2016-04-15",
+            "service_end": "2016-04-15",
+            "amount": {
+              "billed": 145,
+              "paid": 33.7,
+              "total_coverage": 99.56,
+              "deduction": null,
+              "tax": null,
+              "total_claim_before_taxes": null,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "quantity": {
+              "billed": 0,
+              "paid": 1,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "additional_ids": [],
+            "rendering_provider_ids": [],
+            "allowed_amount": 99.56,
+            "remark_codes": [],
+            "provider_control_number": "123123123",
+            "healthcare_policy": [],
+            "adjustments": [
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "1",
+                "reason_label": "Deductible Amount",
+                "amount": 40.88,
+                "quantity": 0
+              },
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "3",
+                "reason_label": "Co-payment Amount",
+                "amount": 20,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "144",
+                "reason_label": "Incentive adjustment, e.g. preferred product/service.",
+                "amount": 4.98,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "45",
+                "reason_label": "Charge exceeds fee schedule/maximum allowable or contracted/legislated fee arrangement. (Use only with Group Codes PR or CO depending upon liability)",
+                "amount": 45.44,
+                "quantity": 0
+              }
+            ]
+          }
+        ]
+      },
+      "reference_id": "B3J4Q6SJ43L1"
+    },
+    {
+      "effective_date": "2016-04-15",
+      "payer": {
+        "name": "BCBSM",
+        "id": "ELIG_SNDBX",
+        "address": {
+          "street_line_1": "600 E LAFAYETTE",
+          "street_line_2": null,
+          "city": "DETROIT",
+          "state": "MI",
+          "zip": "482260000"
+        },
+        "contacts": [
+          {
+            "department_code": "CX",
+            "department_label": "Payers Claim Office. Location responsible for paying bills related to medical care received",
+            "name": "EDI HELPDESK",
+            "details": [
+              {
+                "type_code": "TE",
+                "type_label": "Telephone",
+                "value": "8005420945"
+              },
+              {
+                "type_code": "FX",
+                "type_label": "Facsimile",
+                "value": "2484862453"
+              }
+            ]
+          },
+          {
+            "department_code": "BL",
+            "department_label": "Technical Department",
+            "name": "EDI HELPDESK",
+            "details": [
+              {
+                "type_code": "TE",
+                "type_label": "Telephone",
+                "value": "8005420945"
+              },
+              {
+                "type_code": "FX",
+                "type_label": "Facsimile",
+                "value": "2484862453"
+              },
+              {
+                "type_code": "EM",
+                "type_label": "Electronic Mail",
+                "value": "EDI@BCBSM.COM"
+              }
+            ]
+          }
+        ],
+        "crossover_payer": null,
+        "corrected_priority_payer": null
+      },
+      "financials": {
+        "type_code": "I",
+        "type_label": "Remittance Information Only",
+        "total_payment_amount": "1261.03",
+        "credit": true,
+        "debit": false,
+        "payment_method_code": "ACH",
+        "payment_method_label": "Automated Clearing House (ACH)",
+        "payment_format_code": "CCP",
+        "payment_format_label": "Cash Concentration/Disbursement plus Addenda (CCD+) (ACH)",
+        "payment_date": "2016-02-03",
+        "payment_trace_number": "710618145",
+        "sender": {
+          "dfi_id_qualifier": "01",
+          "dfi_id_qualifier_label": "ABA Transit Routing Number Including Check Digits (9 digits)",
+          "dfi_id": "091000019",
+          "account_number": "1382069753",
+          "id": "1382069753",
+          "supplemental_code": ""
+        },
+        "receiver": {
+          "dfi_id_qualifier": "01",
+          "dfi_id_qualifier_label": "ABA Transit Routing Number Including Check Digits (9 digits)",
+          "dfi_id": "072000096",
+          "account_type": "Demand Deposit",
+          "account_number": "1852205283"
+        }
+      },
+      "payee": {
+        "name": "JENNIFER DESCHRYVER INC",
+        "npi": "1932382397",
+        "address": {
+          "street_line_1": null,
+          "street_line_2": null,
+          "city": "BLOOMFLD HLS",
+          "state": "MI",
+          "zip": "483013068"
+        },
+        "additional_ids": [
+          {
+            "type_code": "TJ",
+            "type_label": "Federal Taxpayer's Identification Number",
+            "value": "123123123"
+          }
+        ],
+        "adjustments": [],
+        "delivery_method": null
+      },
+      "patient": {
+        "first_name": "*****MIN",
+        "last_name": "*****LIN",
+        "middle_name": "J",
+        "id": "*******890"
+      },
+      "corrected_patient": {
+        "first_name": null,
+        "last_name": null,
+        "middle_name": null,
+        "id": null
+      },
+      "other_patient": {
+        "first_name": null,
+        "last_name": null,
+        "middle_name": null,
+        "id": null
+      },
+      "service_provider": null,
+      "claim": {
+        "control_number": "26160262372500710",
+        "received_date": "2016-04-15",
+        "expiration_date": null,
+        "filing_indicator_type": "12",
+        "filing_indicator_label": "Preferred Provider Organization (PPO)",
+        "place_of_service": "11",
+        "frequency": "1",
+        "responsibility_sequence": "primary",
+        "status": [
+          "processed"
+        ],
+        "drg_code": null,
+        "drg_quantity": null,
+        "amount": {
+          "billed": 435,
+          "paid": 33.7,
+          "patient_responsibility": 260,
+          "total_coverage": 298.68,
+          "prompt_payment_discount": null,
+          "per_day_limit": null,
+          "patient_paid": null,
+          "revised_interest": null,
+          "negative_ledger_balance": null,
+          "tax": null,
+          "total_claim_before_taxes": null,
+          "federal": {
+            "category_1": null,
+            "category_2": null,
+            "category_3": null,
+            "category_4": null,
+            "category_5": null
+          }
+        },
+        "adjustments": [],
+        "quantity": {
+          "actual": {
+            "covered": null,
+            "co_insured": null,
+            "life_time_reserve": null
+          },
+          "estimated": {
+            "life_time_reserve": null,
+            "non_covered": null
+          },
+          "not_replaced_blood_unit": null,
+          "outlier_days": null,
+          "prescription": null,
+          "visits": null,
+          "federal": {
+            "category_1": null,
+            "category_2": null,
+            "category_3": null,
+            "category_4": null,
+            "category_5": null
+          }
+        },
+        "additional_ids": [],
+        "rendering_provider_ids": [],
+        "moa_codes": [],
+        "allowed_amount": 298.68,
+        "contacts": [],
+        "service_lines": [
+          {
+            "procedure_qualifier": "HC<90834",
+            "procedure_code": null,
+            "procedure_modifiers": [],
+            "revenue_code": "",
+            "service_start": "2016-04-15",
+            "service_end": "2016-04-15",
+            "amount": {
+              "billed": 145,
+              "paid": 0,
+              "total_coverage": 99.56,
+              "deduction": null,
+              "tax": null,
+              "total_claim_before_taxes": null,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "quantity": {
+              "billed": 0,
+              "paid": 1,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "additional_ids": [],
+            "rendering_provider_ids": [],
+            "allowed_amount": 99.56,
+            "remark_codes": [],
+            "provider_control_number": "123123123",
+            "healthcare_policy": [],
+            "adjustments": [
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "1",
+                "reason_label": "Deductible Amount",
+                "amount": 79.56,
+                "quantity": 0
+              },
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "3",
+                "reason_label": "Co-payment Amount",
+                "amount": 20,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "45",
+                "reason_label": "Charge exceeds fee schedule/maximum allowable or contracted/legislated fee arrangement. (Use only with Group Codes PR or CO depending upon liability)",
+                "amount": 45.44,
+                "quantity": 0
+              }
+            ]
+          },
+          {
+            "procedure_qualifier": "HC<90834",
+            "procedure_code": null,
+            "procedure_modifiers": [],
+            "revenue_code": "",
+            "service_start": "2016-04-15",
+            "service_end": "2016-04-15",
+            "amount": {
+              "billed": 145,
+              "paid": 0,
+              "total_coverage": 99.56,
+              "deduction": null,
+              "tax": null,
+              "total_claim_before_taxes": null,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "quantity": {
+              "billed": 0,
+              "paid": 1,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "additional_ids": [],
+            "rendering_provider_ids": [],
+            "allowed_amount": 99.56,
+            "remark_codes": [],
+            "provider_control_number": "123123123",
+            "healthcare_policy": [],
+            "adjustments": [
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "1",
+                "reason_label": "Deductible Amount",
+                "amount": 79.56,
+                "quantity": 0
+              },
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "3",
+                "reason_label": "Co-payment Amount",
+                "amount": 20,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "45",
+                "reason_label": "Charge exceeds fee schedule/maximum allowable or contracted/legislated fee arrangement. (Use only with Group Codes PR or CO depending upon liability)",
+                "amount": 45.44,
+                "quantity": 0
+              }
+            ]
+          },
+          {
+            "procedure_qualifier": "HC<90834",
+            "procedure_code": null,
+            "procedure_modifiers": [],
+            "revenue_code": "",
+            "service_start": "2016-04-15",
+            "service_end": "2016-04-15",
+            "amount": {
+              "billed": 145,
+              "paid": 33.7,
+              "total_coverage": 99.56,
+              "deduction": null,
+              "tax": null,
+              "total_claim_before_taxes": null,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "quantity": {
+              "billed": 0,
+              "paid": 1,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "additional_ids": [],
+            "rendering_provider_ids": [],
+            "allowed_amount": 99.56,
+            "remark_codes": [],
+            "provider_control_number": "123123123",
+            "healthcare_policy": [],
+            "adjustments": [
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "1",
+                "reason_label": "Deductible Amount",
+                "amount": 40.88,
+                "quantity": 0
+              },
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "3",
+                "reason_label": "Co-payment Amount",
+                "amount": 20,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "144",
+                "reason_label": "Incentive adjustment, e.g. preferred product/service.",
+                "amount": 4.98,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "45",
+                "reason_label": "Charge exceeds fee schedule/maximum allowable or contracted/legislated fee arrangement. (Use only with Group Codes PR or CO depending upon liability)",
+                "amount": 45.44,
+                "quantity": 0
+              }
+            ]
+          }
+        ]
+      },
+      "reference_id": "B3J4Q6SJ43L1"
+    },
+    {
+      "effective_date": "2016-04-15",
+      "payer": {
+        "name": "BCBSM",
+        "id": "ELIG_SNDBX",
+        "address": {
+          "street_line_1": "600 E LAFAYETTE",
+          "street_line_2": null,
+          "city": "DETROIT",
+          "state": "MI",
+          "zip": "482260000"
+        },
+        "contacts": [
+          {
+            "department_code": "CX",
+            "department_label": "Payers Claim Office. Location responsible for paying bills related to medical care received",
+            "name": "EDI HELPDESK",
+            "details": [
+              {
+                "type_code": "TE",
+                "type_label": "Telephone",
+                "value": "8005420945"
+              },
+              {
+                "type_code": "FX",
+                "type_label": "Facsimile",
+                "value": "2484862453"
+              }
+            ]
+          },
+          {
+            "department_code": "BL",
+            "department_label": "Technical Department",
+            "name": "EDI HELPDESK",
+            "details": [
+              {
+                "type_code": "TE",
+                "type_label": "Telephone",
+                "value": "8005420945"
+              },
+              {
+                "type_code": "FX",
+                "type_label": "Facsimile",
+                "value": "2484862453"
+              },
+              {
+                "type_code": "EM",
+                "type_label": "Electronic Mail",
+                "value": "EDI@BCBSM.COM"
+              }
+            ]
+          }
+        ],
+        "crossover_payer": null,
+        "corrected_priority_payer": null
+      },
+      "financials": {
+        "type_code": "I",
+        "type_label": "Remittance Information Only",
+        "total_payment_amount": "1261.03",
+        "credit": true,
+        "debit": false,
+        "payment_method_code": "ACH",
+        "payment_method_label": "Automated Clearing House (ACH)",
+        "payment_format_code": "CCP",
+        "payment_format_label": "Cash Concentration/Disbursement plus Addenda (CCD+) (ACH)",
+        "payment_date": "2016-02-03",
+        "payment_trace_number": "710618145",
+        "sender": {
+          "dfi_id_qualifier": "01",
+          "dfi_id_qualifier_label": "ABA Transit Routing Number Including Check Digits (9 digits)",
+          "dfi_id": "091000019",
+          "account_number": "1382069753",
+          "id": "1382069753",
+          "supplemental_code": ""
+        },
+        "receiver": {
+          "dfi_id_qualifier": "01",
+          "dfi_id_qualifier_label": "ABA Transit Routing Number Including Check Digits (9 digits)",
+          "dfi_id": "072000096",
+          "account_type": "Demand Deposit",
+          "account_number": "1852205283"
+        }
+      },
+      "payee": {
+        "name": "JENNIFER DESCHRYVER INC",
+        "npi": "1932382397",
+        "address": {
+          "street_line_1": null,
+          "street_line_2": null,
+          "city": "BLOOMFLD HLS",
+          "state": "MI",
+          "zip": "483013068"
+        },
+        "additional_ids": [
+          {
+            "type_code": "TJ",
+            "type_label": "Federal Taxpayer's Identification Number",
+            "value": "123123123"
+          }
+        ],
+        "adjustments": [],
+        "delivery_method": null
+      },
+      "patient": {
+        "first_name": "*****MIN",
+        "last_name": "*****LIN",
+        "middle_name": "J",
+        "id": "*******890"
+      },
+      "corrected_patient": {
+        "first_name": null,
+        "last_name": null,
+        "middle_name": null,
+        "id": null
+      },
+      "other_patient": {
+        "first_name": null,
+        "last_name": null,
+        "middle_name": null,
+        "id": null
+      },
+      "service_provider": null,
+      "claim": {
+        "control_number": "26160262372500710",
+        "received_date": "2016-04-15",
+        "expiration_date": null,
+        "filing_indicator_type": "12",
+        "filing_indicator_label": "Preferred Provider Organization (PPO)",
+        "place_of_service": "11",
+        "frequency": "1",
+        "responsibility_sequence": "primary",
+        "status": [
+          "processed"
+        ],
+        "drg_code": null,
+        "drg_quantity": null,
+        "amount": {
+          "billed": 435,
+          "paid": 33.7,
+          "patient_responsibility": 260,
+          "total_coverage": 298.68,
+          "prompt_payment_discount": null,
+          "per_day_limit": null,
+          "patient_paid": null,
+          "revised_interest": null,
+          "negative_ledger_balance": null,
+          "tax": null,
+          "total_claim_before_taxes": null,
+          "federal": {
+            "category_1": null,
+            "category_2": null,
+            "category_3": null,
+            "category_4": null,
+            "category_5": null
+          }
+        },
+        "adjustments": [],
+        "quantity": {
+          "actual": {
+            "covered": null,
+            "co_insured": null,
+            "life_time_reserve": null
+          },
+          "estimated": {
+            "life_time_reserve": null,
+            "non_covered": null
+          },
+          "not_replaced_blood_unit": null,
+          "outlier_days": null,
+          "prescription": null,
+          "visits": null,
+          "federal": {
+            "category_1": null,
+            "category_2": null,
+            "category_3": null,
+            "category_4": null,
+            "category_5": null
+          }
+        },
+        "additional_ids": [],
+        "rendering_provider_ids": [],
+        "moa_codes": [],
+        "allowed_amount": 298.68,
+        "contacts": [],
+        "service_lines": [
+          {
+            "procedure_qualifier": "HC<90834",
+            "procedure_code": null,
+            "procedure_modifiers": [],
+            "revenue_code": "",
+            "service_start": "2016-04-15",
+            "service_end": "2016-04-15",
+            "amount": {
+              "billed": 145,
+              "paid": 0,
+              "total_coverage": 99.56,
+              "deduction": null,
+              "tax": null,
+              "total_claim_before_taxes": null,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "quantity": {
+              "billed": 0,
+              "paid": 1,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "additional_ids": [],
+            "rendering_provider_ids": [],
+            "allowed_amount": 99.56,
+            "remark_codes": [],
+            "provider_control_number": "123123123",
+            "healthcare_policy": [],
+            "adjustments": [
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "1",
+                "reason_label": "Deductible Amount",
+                "amount": 79.56,
+                "quantity": 0
+              },
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "3",
+                "reason_label": "Co-payment Amount",
+                "amount": 20,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "45",
+                "reason_label": "Charge exceeds fee schedule/maximum allowable or contracted/legislated fee arrangement. (Use only with Group Codes PR or CO depending upon liability)",
+                "amount": 45.44,
+                "quantity": 0
+              }
+            ]
+          },
+          {
+            "procedure_qualifier": "HC<90834",
+            "procedure_code": null,
+            "procedure_modifiers": [],
+            "revenue_code": "",
+            "service_start": "2016-04-15",
+            "service_end": "2016-04-15",
+            "amount": {
+              "billed": 145,
+              "paid": 0,
+              "total_coverage": 99.56,
+              "deduction": null,
+              "tax": null,
+              "total_claim_before_taxes": null,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "quantity": {
+              "billed": 0,
+              "paid": 1,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "additional_ids": [],
+            "rendering_provider_ids": [],
+            "allowed_amount": 99.56,
+            "remark_codes": [],
+            "provider_control_number": "123123123",
+            "healthcare_policy": [],
+            "adjustments": [
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "1",
+                "reason_label": "Deductible Amount",
+                "amount": 79.56,
+                "quantity": 0
+              },
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "3",
+                "reason_label": "Co-payment Amount",
+                "amount": 20,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "45",
+                "reason_label": "Charge exceeds fee schedule/maximum allowable or contracted/legislated fee arrangement. (Use only with Group Codes PR or CO depending upon liability)",
+                "amount": 45.44,
+                "quantity": 0
+              }
+            ]
+          },
+          {
+            "procedure_qualifier": "HC<90834",
+            "procedure_code": null,
+            "procedure_modifiers": [],
+            "revenue_code": "",
+            "service_start": "2016-04-15",
+            "service_end": "2016-04-15",
+            "amount": {
+              "billed": 145,
+              "paid": 33.7,
+              "total_coverage": 99.56,
+              "deduction": null,
+              "tax": null,
+              "total_claim_before_taxes": null,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "quantity": {
+              "billed": 0,
+              "paid": 1,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "additional_ids": [],
+            "rendering_provider_ids": [],
+            "allowed_amount": 99.56,
+            "remark_codes": [],
+            "provider_control_number": "123123123",
+            "healthcare_policy": [],
+            "adjustments": [
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "1",
+                "reason_label": "Deductible Amount",
+                "amount": 40.88,
+                "quantity": 0
+              },
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "3",
+                "reason_label": "Co-payment Amount",
+                "amount": 20,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "144",
+                "reason_label": "Incentive adjustment, e.g. preferred product/service.",
+                "amount": 4.98,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "45",
+                "reason_label": "Charge exceeds fee schedule/maximum allowable or contracted/legislated fee arrangement. (Use only with Group Codes PR or CO depending upon liability)",
+                "amount": 45.44,
+                "quantity": 0
+              }
+            ]
+          }
+        ]
+      },
+      "reference_id": "32ZBB9KEJI2GN"
+    },
+    {
+      "effective_date": "2016-04-15",
+      "payer": {
+        "name": "BCBSM",
+        "id": "ELIG_SNDBX",
+        "address": {
+          "street_line_1": "600 E LAFAYETTE",
+          "street_line_2": null,
+          "city": "DETROIT",
+          "state": "MI",
+          "zip": "482260000"
+        },
+        "contacts": [
+          {
+            "department_code": "CX",
+            "department_label": "Payers Claim Office. Location responsible for paying bills related to medical care received",
+            "name": "EDI HELPDESK",
+            "details": [
+              {
+                "type_code": "TE",
+                "type_label": "Telephone",
+                "value": "8005420945"
+              },
+              {
+                "type_code": "FX",
+                "type_label": "Facsimile",
+                "value": "2484862453"
+              }
+            ]
+          },
+          {
+            "department_code": "BL",
+            "department_label": "Technical Department",
+            "name": "EDI HELPDESK",
+            "details": [
+              {
+                "type_code": "TE",
+                "type_label": "Telephone",
+                "value": "8005420945"
+              },
+              {
+                "type_code": "FX",
+                "type_label": "Facsimile",
+                "value": "2484862453"
+              },
+              {
+                "type_code": "EM",
+                "type_label": "Electronic Mail",
+                "value": "EDI@BCBSM.COM"
+              }
+            ]
+          }
+        ],
+        "crossover_payer": null,
+        "corrected_priority_payer": null
+      },
+      "financials": {
+        "type_code": "I",
+        "type_label": "Remittance Information Only",
+        "total_payment_amount": "1261.03",
+        "credit": true,
+        "debit": false,
+        "payment_method_code": "ACH",
+        "payment_method_label": "Automated Clearing House (ACH)",
+        "payment_format_code": "CCP",
+        "payment_format_label": "Cash Concentration/Disbursement plus Addenda (CCD+) (ACH)",
+        "payment_date": "2016-02-03",
+        "payment_trace_number": "710618145",
+        "sender": {
+          "dfi_id_qualifier": "01",
+          "dfi_id_qualifier_label": "ABA Transit Routing Number Including Check Digits (9 digits)",
+          "dfi_id": "091000019",
+          "account_number": "1382069753",
+          "id": "1382069753",
+          "supplemental_code": ""
+        },
+        "receiver": {
+          "dfi_id_qualifier": "01",
+          "dfi_id_qualifier_label": "ABA Transit Routing Number Including Check Digits (9 digits)",
+          "dfi_id": "072000096",
+          "account_type": "Demand Deposit",
+          "account_number": "1852205283"
+        }
+      },
+      "payee": {
+        "name": "JENNIFER DESCHRYVER INC",
+        "npi": "1932382397",
+        "address": {
+          "street_line_1": null,
+          "street_line_2": null,
+          "city": "BLOOMFLD HLS",
+          "state": "MI",
+          "zip": "483013068"
+        },
+        "additional_ids": [
+          {
+            "type_code": "TJ",
+            "type_label": "Federal Taxpayer's Identification Number",
+            "value": "123123123"
+          }
+        ],
+        "adjustments": [],
+        "delivery_method": null
+      },
+      "patient": {
+        "first_name": "*****MIN",
+        "last_name": "*****LIN",
+        "middle_name": "J",
+        "id": "*******890"
+      },
+      "corrected_patient": {
+        "first_name": null,
+        "last_name": null,
+        "middle_name": null,
+        "id": null
+      },
+      "other_patient": {
+        "first_name": null,
+        "last_name": null,
+        "middle_name": null,
+        "id": null
+      },
+      "service_provider": null,
+      "claim": {
+        "control_number": "26160262372500710",
+        "received_date": "2016-04-15",
+        "expiration_date": null,
+        "filing_indicator_type": "12",
+        "filing_indicator_label": "Preferred Provider Organization (PPO)",
+        "place_of_service": "11",
+        "frequency": "1",
+        "responsibility_sequence": "primary",
+        "status": [
+          "processed"
+        ],
+        "drg_code": null,
+        "drg_quantity": null,
+        "amount": {
+          "billed": 435,
+          "paid": 33.7,
+          "patient_responsibility": 260,
+          "total_coverage": 298.68,
+          "prompt_payment_discount": null,
+          "per_day_limit": null,
+          "patient_paid": null,
+          "revised_interest": null,
+          "negative_ledger_balance": null,
+          "tax": null,
+          "total_claim_before_taxes": null,
+          "federal": {
+            "category_1": null,
+            "category_2": null,
+            "category_3": null,
+            "category_4": null,
+            "category_5": null
+          }
+        },
+        "adjustments": [],
+        "quantity": {
+          "actual": {
+            "covered": null,
+            "co_insured": null,
+            "life_time_reserve": null
+          },
+          "estimated": {
+            "life_time_reserve": null,
+            "non_covered": null
+          },
+          "not_replaced_blood_unit": null,
+          "outlier_days": null,
+          "prescription": null,
+          "visits": null,
+          "federal": {
+            "category_1": null,
+            "category_2": null,
+            "category_3": null,
+            "category_4": null,
+            "category_5": null
+          }
+        },
+        "additional_ids": [],
+        "rendering_provider_ids": [],
+        "moa_codes": [],
+        "allowed_amount": 298.68,
+        "contacts": [],
+        "service_lines": [
+          {
+            "procedure_qualifier": "HC<90834",
+            "procedure_code": null,
+            "procedure_modifiers": [],
+            "revenue_code": "",
+            "service_start": "2016-04-15",
+            "service_end": "2016-04-15",
+            "amount": {
+              "billed": 145,
+              "paid": 0,
+              "total_coverage": 99.56,
+              "deduction": null,
+              "tax": null,
+              "total_claim_before_taxes": null,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "quantity": {
+              "billed": 0,
+              "paid": 1,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "additional_ids": [],
+            "rendering_provider_ids": [],
+            "allowed_amount": 99.56,
+            "remark_codes": [],
+            "provider_control_number": "123123123",
+            "healthcare_policy": [],
+            "adjustments": [
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "1",
+                "reason_label": "Deductible Amount",
+                "amount": 79.56,
+                "quantity": 0
+              },
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "3",
+                "reason_label": "Co-payment Amount",
+                "amount": 20,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "45",
+                "reason_label": "Charge exceeds fee schedule/maximum allowable or contracted/legislated fee arrangement. (Use only with Group Codes PR or CO depending upon liability)",
+                "amount": 45.44,
+                "quantity": 0
+              }
+            ]
+          },
+          {
+            "procedure_qualifier": "HC<90834",
+            "procedure_code": null,
+            "procedure_modifiers": [],
+            "revenue_code": "",
+            "service_start": "2016-04-15",
+            "service_end": "2016-04-15",
+            "amount": {
+              "billed": 145,
+              "paid": 0,
+              "total_coverage": 99.56,
+              "deduction": null,
+              "tax": null,
+              "total_claim_before_taxes": null,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "quantity": {
+              "billed": 0,
+              "paid": 1,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "additional_ids": [],
+            "rendering_provider_ids": [],
+            "allowed_amount": 99.56,
+            "remark_codes": [],
+            "provider_control_number": "123123123",
+            "healthcare_policy": [],
+            "adjustments": [
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "1",
+                "reason_label": "Deductible Amount",
+                "amount": 79.56,
+                "quantity": 0
+              },
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "3",
+                "reason_label": "Co-payment Amount",
+                "amount": 20,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "45",
+                "reason_label": "Charge exceeds fee schedule/maximum allowable or contracted/legislated fee arrangement. (Use only with Group Codes PR or CO depending upon liability)",
+                "amount": 45.44,
+                "quantity": 0
+              }
+            ]
+          },
+          {
+            "procedure_qualifier": "HC<90834",
+            "procedure_code": null,
+            "procedure_modifiers": [],
+            "revenue_code": "",
+            "service_start": "2016-04-15",
+            "service_end": "2016-04-15",
+            "amount": {
+              "billed": 145,
+              "paid": 33.7,
+              "total_coverage": 99.56,
+              "deduction": null,
+              "tax": null,
+              "total_claim_before_taxes": null,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "quantity": {
+              "billed": 0,
+              "paid": 1,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "additional_ids": [],
+            "rendering_provider_ids": [],
+            "allowed_amount": 99.56,
+            "remark_codes": [],
+            "provider_control_number": "123123123",
+            "healthcare_policy": [],
+            "adjustments": [
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "1",
+                "reason_label": "Deductible Amount",
+                "amount": 40.88,
+                "quantity": 0
+              },
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "3",
+                "reason_label": "Co-payment Amount",
+                "amount": 20,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "144",
+                "reason_label": "Incentive adjustment, e.g. preferred product/service.",
+                "amount": 4.98,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "45",
+                "reason_label": "Charge exceeds fee schedule/maximum allowable or contracted/legislated fee arrangement. (Use only with Group Codes PR or CO depending upon liability)",
+                "amount": 45.44,
+                "quantity": 0
+              }
+            ]
+          }
+        ]
+      },
+      "reference_id": "32ZBB9KEJI2GN"
+    },
+    {
+      "effective_date": "2016-04-15",
+      "payer": {
+        "name": "BCBSM",
+        "id": "ELIG_SNDBX",
+        "address": {
+          "street_line_1": "600 E LAFAYETTE",
+          "street_line_2": null,
+          "city": "DETROIT",
+          "state": "MI",
+          "zip": "482260000"
+        },
+        "contacts": [
+          {
+            "department_code": "CX",
+            "department_label": "Payers Claim Office. Location responsible for paying bills related to medical care received",
+            "name": "EDI HELPDESK",
+            "details": [
+              {
+                "type_code": "TE",
+                "type_label": "Telephone",
+                "value": "8005420945"
+              },
+              {
+                "type_code": "FX",
+                "type_label": "Facsimile",
+                "value": "2484862453"
+              }
+            ]
+          },
+          {
+            "department_code": "BL",
+            "department_label": "Technical Department",
+            "name": "EDI HELPDESK",
+            "details": [
+              {
+                "type_code": "TE",
+                "type_label": "Telephone",
+                "value": "8005420945"
+              },
+              {
+                "type_code": "FX",
+                "type_label": "Facsimile",
+                "value": "2484862453"
+              },
+              {
+                "type_code": "EM",
+                "type_label": "Electronic Mail",
+                "value": "EDI@BCBSM.COM"
+              }
+            ]
+          }
+        ],
+        "crossover_payer": null,
+        "corrected_priority_payer": null
+      },
+      "financials": {
+        "type_code": "I",
+        "type_label": "Remittance Information Only",
+        "total_payment_amount": "1261.03",
+        "credit": true,
+        "debit": false,
+        "payment_method_code": "ACH",
+        "payment_method_label": "Automated Clearing House (ACH)",
+        "payment_format_code": "CCP",
+        "payment_format_label": "Cash Concentration/Disbursement plus Addenda (CCD+) (ACH)",
+        "payment_date": "2016-02-03",
+        "payment_trace_number": "710618145",
+        "sender": {
+          "dfi_id_qualifier": "01",
+          "dfi_id_qualifier_label": "ABA Transit Routing Number Including Check Digits (9 digits)",
+          "dfi_id": "091000019",
+          "account_number": "1382069753",
+          "id": "1382069753",
+          "supplemental_code": ""
+        },
+        "receiver": {
+          "dfi_id_qualifier": "01",
+          "dfi_id_qualifier_label": "ABA Transit Routing Number Including Check Digits (9 digits)",
+          "dfi_id": "072000096",
+          "account_type": "Demand Deposit",
+          "account_number": "1852205283"
+        }
+      },
+      "payee": {
+        "name": "JENNIFER DESCHRYVER INC",
+        "npi": "1932382397",
+        "address": {
+          "street_line_1": null,
+          "street_line_2": null,
+          "city": "BLOOMFLD HLS",
+          "state": "MI",
+          "zip": "483013068"
+        },
+        "additional_ids": [
+          {
+            "type_code": "TJ",
+            "type_label": "Federal Taxpayer's Identification Number",
+            "value": "123123123"
+          }
+        ],
+        "adjustments": [],
+        "delivery_method": null
+      },
+      "patient": {
+        "first_name": "*****MIN",
+        "last_name": "*****LIN",
+        "middle_name": "J",
+        "id": "*******890"
+      },
+      "corrected_patient": {
+        "first_name": null,
+        "last_name": null,
+        "middle_name": null,
+        "id": null
+      },
+      "other_patient": {
+        "first_name": null,
+        "last_name": null,
+        "middle_name": null,
+        "id": null
+      },
+      "service_provider": null,
+      "claim": {
+        "control_number": "26160262372500710",
+        "received_date": "2016-04-15",
+        "expiration_date": null,
+        "filing_indicator_type": "12",
+        "filing_indicator_label": "Preferred Provider Organization (PPO)",
+        "place_of_service": "11",
+        "frequency": "1",
+        "responsibility_sequence": "primary",
+        "status": [
+          "processed"
+        ],
+        "drg_code": null,
+        "drg_quantity": null,
+        "amount": {
+          "billed": 435,
+          "paid": 33.7,
+          "patient_responsibility": 260,
+          "total_coverage": 298.68,
+          "prompt_payment_discount": null,
+          "per_day_limit": null,
+          "patient_paid": null,
+          "revised_interest": null,
+          "negative_ledger_balance": null,
+          "tax": null,
+          "total_claim_before_taxes": null,
+          "federal": {
+            "category_1": null,
+            "category_2": null,
+            "category_3": null,
+            "category_4": null,
+            "category_5": null
+          }
+        },
+        "adjustments": [],
+        "quantity": {
+          "actual": {
+            "covered": null,
+            "co_insured": null,
+            "life_time_reserve": null
+          },
+          "estimated": {
+            "life_time_reserve": null,
+            "non_covered": null
+          },
+          "not_replaced_blood_unit": null,
+          "outlier_days": null,
+          "prescription": null,
+          "visits": null,
+          "federal": {
+            "category_1": null,
+            "category_2": null,
+            "category_3": null,
+            "category_4": null,
+            "category_5": null
+          }
+        },
+        "additional_ids": [],
+        "rendering_provider_ids": [],
+        "moa_codes": [],
+        "allowed_amount": 298.68,
+        "contacts": [],
+        "service_lines": [
+          {
+            "procedure_qualifier": "HC<90834",
+            "procedure_code": null,
+            "procedure_modifiers": [],
+            "revenue_code": "",
+            "service_start": "2016-04-15",
+            "service_end": "2016-04-15",
+            "amount": {
+              "billed": 145,
+              "paid": 0,
+              "total_coverage": 99.56,
+              "deduction": null,
+              "tax": null,
+              "total_claim_before_taxes": null,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "quantity": {
+              "billed": 0,
+              "paid": 1,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "additional_ids": [],
+            "rendering_provider_ids": [],
+            "allowed_amount": 99.56,
+            "remark_codes": [],
+            "provider_control_number": "123123123",
+            "healthcare_policy": [],
+            "adjustments": [
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "1",
+                "reason_label": "Deductible Amount",
+                "amount": 79.56,
+                "quantity": 0
+              },
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "3",
+                "reason_label": "Co-payment Amount",
+                "amount": 20,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "45",
+                "reason_label": "Charge exceeds fee schedule/maximum allowable or contracted/legislated fee arrangement. (Use only with Group Codes PR or CO depending upon liability)",
+                "amount": 45.44,
+                "quantity": 0
+              }
+            ]
+          },
+          {
+            "procedure_qualifier": "HC<90834",
+            "procedure_code": null,
+            "procedure_modifiers": [],
+            "revenue_code": "",
+            "service_start": "2016-04-15",
+            "service_end": "2016-04-15",
+            "amount": {
+              "billed": 145,
+              "paid": 0,
+              "total_coverage": 99.56,
+              "deduction": null,
+              "tax": null,
+              "total_claim_before_taxes": null,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "quantity": {
+              "billed": 0,
+              "paid": 1,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "additional_ids": [],
+            "rendering_provider_ids": [],
+            "allowed_amount": 99.56,
+            "remark_codes": [],
+            "provider_control_number": "123123123",
+            "healthcare_policy": [],
+            "adjustments": [
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "1",
+                "reason_label": "Deductible Amount",
+                "amount": 79.56,
+                "quantity": 0
+              },
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "3",
+                "reason_label": "Co-payment Amount",
+                "amount": 20,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "45",
+                "reason_label": "Charge exceeds fee schedule/maximum allowable or contracted/legislated fee arrangement. (Use only with Group Codes PR or CO depending upon liability)",
+                "amount": 45.44,
+                "quantity": 0
+              }
+            ]
+          },
+          {
+            "procedure_qualifier": "HC<90834",
+            "procedure_code": null,
+            "procedure_modifiers": [],
+            "revenue_code": "",
+            "service_start": "2016-04-15",
+            "service_end": "2016-04-15",
+            "amount": {
+              "billed": 145,
+              "paid": 33.7,
+              "total_coverage": 99.56,
+              "deduction": null,
+              "tax": null,
+              "total_claim_before_taxes": null,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "quantity": {
+              "billed": 0,
+              "paid": 1,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "additional_ids": [],
+            "rendering_provider_ids": [],
+            "allowed_amount": 99.56,
+            "remark_codes": [],
+            "provider_control_number": "123123123",
+            "healthcare_policy": [],
+            "adjustments": [
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "1",
+                "reason_label": "Deductible Amount",
+                "amount": 40.88,
+                "quantity": 0
+              },
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "3",
+                "reason_label": "Co-payment Amount",
+                "amount": 20,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "144",
+                "reason_label": "Incentive adjustment, e.g. preferred product/service.",
+                "amount": 4.98,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "45",
+                "reason_label": "Charge exceeds fee schedule/maximum allowable or contracted/legislated fee arrangement. (Use only with Group Codes PR or CO depending upon liability)",
+                "amount": 45.44,
+                "quantity": 0
+              }
+            ]
+          }
+        ]
+      },
+      "reference_id": "8KA3FAZF9B2H99"
+    },
+    {
+      "effective_date": "2016-04-15",
+      "payer": {
+        "name": "BCBSM",
+        "id": "ELIG_SNDBX",
+        "address": {
+          "street_line_1": "600 E LAFAYETTE",
+          "street_line_2": null,
+          "city": "DETROIT",
+          "state": "MI",
+          "zip": "482260000"
+        },
+        "contacts": [
+          {
+            "department_code": "CX",
+            "department_label": "Payers Claim Office. Location responsible for paying bills related to medical care received",
+            "name": "EDI HELPDESK",
+            "details": [
+              {
+                "type_code": "TE",
+                "type_label": "Telephone",
+                "value": "8005420945"
+              },
+              {
+                "type_code": "FX",
+                "type_label": "Facsimile",
+                "value": "2484862453"
+              }
+            ]
+          },
+          {
+            "department_code": "BL",
+            "department_label": "Technical Department",
+            "name": "EDI HELPDESK",
+            "details": [
+              {
+                "type_code": "TE",
+                "type_label": "Telephone",
+                "value": "8005420945"
+              },
+              {
+                "type_code": "FX",
+                "type_label": "Facsimile",
+                "value": "2484862453"
+              },
+              {
+                "type_code": "EM",
+                "type_label": "Electronic Mail",
+                "value": "EDI@BCBSM.COM"
+              }
+            ]
+          }
+        ],
+        "crossover_payer": null,
+        "corrected_priority_payer": null
+      },
+      "financials": {
+        "type_code": "I",
+        "type_label": "Remittance Information Only",
+        "total_payment_amount": "1261.03",
+        "credit": true,
+        "debit": false,
+        "payment_method_code": "ACH",
+        "payment_method_label": "Automated Clearing House (ACH)",
+        "payment_format_code": "CCP",
+        "payment_format_label": "Cash Concentration/Disbursement plus Addenda (CCD+) (ACH)",
+        "payment_date": "2016-02-03",
+        "payment_trace_number": "710618145",
+        "sender": {
+          "dfi_id_qualifier": "01",
+          "dfi_id_qualifier_label": "ABA Transit Routing Number Including Check Digits (9 digits)",
+          "dfi_id": "091000019",
+          "account_number": "1382069753",
+          "id": "1382069753",
+          "supplemental_code": ""
+        },
+        "receiver": {
+          "dfi_id_qualifier": "01",
+          "dfi_id_qualifier_label": "ABA Transit Routing Number Including Check Digits (9 digits)",
+          "dfi_id": "072000096",
+          "account_type": "Demand Deposit",
+          "account_number": "1852205283"
+        }
+      },
+      "payee": {
+        "name": "JENNIFER DESCHRYVER INC",
+        "npi": "1932382397",
+        "address": {
+          "street_line_1": null,
+          "street_line_2": null,
+          "city": "BLOOMFLD HLS",
+          "state": "MI",
+          "zip": "483013068"
+        },
+        "additional_ids": [
+          {
+            "type_code": "TJ",
+            "type_label": "Federal Taxpayer's Identification Number",
+            "value": "123123123"
+          }
+        ],
+        "adjustments": [],
+        "delivery_method": null
+      },
+      "patient": {
+        "first_name": "*****MIN",
+        "last_name": "*****LIN",
+        "middle_name": "J",
+        "id": "*******890"
+      },
+      "corrected_patient": {
+        "first_name": null,
+        "last_name": null,
+        "middle_name": null,
+        "id": null
+      },
+      "other_patient": {
+        "first_name": null,
+        "last_name": null,
+        "middle_name": null,
+        "id": null
+      },
+      "service_provider": null,
+      "claim": {
+        "control_number": "26160262372500710",
+        "received_date": "2016-04-15",
+        "expiration_date": null,
+        "filing_indicator_type": "12",
+        "filing_indicator_label": "Preferred Provider Organization (PPO)",
+        "place_of_service": "11",
+        "frequency": "1",
+        "responsibility_sequence": "primary",
+        "status": [
+          "processed"
+        ],
+        "drg_code": null,
+        "drg_quantity": null,
+        "amount": {
+          "billed": 435,
+          "paid": 33.7,
+          "patient_responsibility": 260,
+          "total_coverage": 298.68,
+          "prompt_payment_discount": null,
+          "per_day_limit": null,
+          "patient_paid": null,
+          "revised_interest": null,
+          "negative_ledger_balance": null,
+          "tax": null,
+          "total_claim_before_taxes": null,
+          "federal": {
+            "category_1": null,
+            "category_2": null,
+            "category_3": null,
+            "category_4": null,
+            "category_5": null
+          }
+        },
+        "adjustments": [],
+        "quantity": {
+          "actual": {
+            "covered": null,
+            "co_insured": null,
+            "life_time_reserve": null
+          },
+          "estimated": {
+            "life_time_reserve": null,
+            "non_covered": null
+          },
+          "not_replaced_blood_unit": null,
+          "outlier_days": null,
+          "prescription": null,
+          "visits": null,
+          "federal": {
+            "category_1": null,
+            "category_2": null,
+            "category_3": null,
+            "category_4": null,
+            "category_5": null
+          }
+        },
+        "additional_ids": [],
+        "rendering_provider_ids": [],
+        "moa_codes": [],
+        "allowed_amount": 298.68,
+        "contacts": [],
+        "service_lines": [
+          {
+            "procedure_qualifier": "HC<90834",
+            "procedure_code": null,
+            "procedure_modifiers": [],
+            "revenue_code": "",
+            "service_start": "2016-04-15",
+            "service_end": "2016-04-15",
+            "amount": {
+              "billed": 145,
+              "paid": 0,
+              "total_coverage": 99.56,
+              "deduction": null,
+              "tax": null,
+              "total_claim_before_taxes": null,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "quantity": {
+              "billed": 0,
+              "paid": 1,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "additional_ids": [],
+            "rendering_provider_ids": [],
+            "allowed_amount": 99.56,
+            "remark_codes": [],
+            "provider_control_number": "123123123",
+            "healthcare_policy": [],
+            "adjustments": [
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "1",
+                "reason_label": "Deductible Amount",
+                "amount": 79.56,
+                "quantity": 0
+              },
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "3",
+                "reason_label": "Co-payment Amount",
+                "amount": 20,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "45",
+                "reason_label": "Charge exceeds fee schedule/maximum allowable or contracted/legislated fee arrangement. (Use only with Group Codes PR or CO depending upon liability)",
+                "amount": 45.44,
+                "quantity": 0
+              }
+            ]
+          },
+          {
+            "procedure_qualifier": "HC<90834",
+            "procedure_code": null,
+            "procedure_modifiers": [],
+            "revenue_code": "",
+            "service_start": "2016-04-15",
+            "service_end": "2016-04-15",
+            "amount": {
+              "billed": 145,
+              "paid": 0,
+              "total_coverage": 99.56,
+              "deduction": null,
+              "tax": null,
+              "total_claim_before_taxes": null,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "quantity": {
+              "billed": 0,
+              "paid": 1,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "additional_ids": [],
+            "rendering_provider_ids": [],
+            "allowed_amount": 99.56,
+            "remark_codes": [],
+            "provider_control_number": "123123123",
+            "healthcare_policy": [],
+            "adjustments": [
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "1",
+                "reason_label": "Deductible Amount",
+                "amount": 79.56,
+                "quantity": 0
+              },
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "3",
+                "reason_label": "Co-payment Amount",
+                "amount": 20,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "45",
+                "reason_label": "Charge exceeds fee schedule/maximum allowable or contracted/legislated fee arrangement. (Use only with Group Codes PR or CO depending upon liability)",
+                "amount": 45.44,
+                "quantity": 0
+              }
+            ]
+          },
+          {
+            "procedure_qualifier": "HC<90834",
+            "procedure_code": null,
+            "procedure_modifiers": [],
+            "revenue_code": "",
+            "service_start": "2016-04-15",
+            "service_end": "2016-04-15",
+            "amount": {
+              "billed": 145,
+              "paid": 33.7,
+              "total_coverage": 99.56,
+              "deduction": null,
+              "tax": null,
+              "total_claim_before_taxes": null,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "quantity": {
+              "billed": 0,
+              "paid": 1,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "additional_ids": [],
+            "rendering_provider_ids": [],
+            "allowed_amount": 99.56,
+            "remark_codes": [],
+            "provider_control_number": "123123123",
+            "healthcare_policy": [],
+            "adjustments": [
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "1",
+                "reason_label": "Deductible Amount",
+                "amount": 40.88,
+                "quantity": 0
+              },
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "3",
+                "reason_label": "Co-payment Amount",
+                "amount": 20,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "144",
+                "reason_label": "Incentive adjustment, e.g. preferred product/service.",
+                "amount": 4.98,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "45",
+                "reason_label": "Charge exceeds fee schedule/maximum allowable or contracted/legislated fee arrangement. (Use only with Group Codes PR or CO depending upon liability)",
+                "amount": 45.44,
+                "quantity": 0
+              }
+            ]
+          }
+        ]
+      },
+      "reference_id": "8KA3FAZF9B2H99"
+    },
+    {
+      "effective_date": "2016-04-15",
+      "payer": {
+        "name": "BCBSM",
+        "id": "ELIG_SNDBX",
+        "address": {
+          "street_line_1": "600 E LAFAYETTE",
+          "street_line_2": null,
+          "city": "DETROIT",
+          "state": "MI",
+          "zip": "482260000"
+        },
+        "contacts": [
+          {
+            "department_code": "CX",
+            "department_label": "Payers Claim Office. Location responsible for paying bills related to medical care received",
+            "name": "EDI HELPDESK",
+            "details": [
+              {
+                "type_code": "TE",
+                "type_label": "Telephone",
+                "value": "8005420945"
+              },
+              {
+                "type_code": "FX",
+                "type_label": "Facsimile",
+                "value": "2484862453"
+              }
+            ]
+          },
+          {
+            "department_code": "BL",
+            "department_label": "Technical Department",
+            "name": "EDI HELPDESK",
+            "details": [
+              {
+                "type_code": "TE",
+                "type_label": "Telephone",
+                "value": "8005420945"
+              },
+              {
+                "type_code": "FX",
+                "type_label": "Facsimile",
+                "value": "2484862453"
+              },
+              {
+                "type_code": "EM",
+                "type_label": "Electronic Mail",
+                "value": "EDI@BCBSM.COM"
+              }
+            ]
+          }
+        ],
+        "crossover_payer": null,
+        "corrected_priority_payer": null
+      },
+      "financials": {
+        "type_code": "I",
+        "type_label": "Remittance Information Only",
+        "total_payment_amount": "1261.03",
+        "credit": true,
+        "debit": false,
+        "payment_method_code": "ACH",
+        "payment_method_label": "Automated Clearing House (ACH)",
+        "payment_format_code": "CCP",
+        "payment_format_label": "Cash Concentration/Disbursement plus Addenda (CCD+) (ACH)",
+        "payment_date": "2016-02-03",
+        "payment_trace_number": "710618145",
+        "sender": {
+          "dfi_id_qualifier": "01",
+          "dfi_id_qualifier_label": "ABA Transit Routing Number Including Check Digits (9 digits)",
+          "dfi_id": "091000019",
+          "account_number": "1382069753",
+          "id": "1382069753",
+          "supplemental_code": ""
+        },
+        "receiver": {
+          "dfi_id_qualifier": "01",
+          "dfi_id_qualifier_label": "ABA Transit Routing Number Including Check Digits (9 digits)",
+          "dfi_id": "072000096",
+          "account_type": "Demand Deposit",
+          "account_number": "1852205283"
+        }
+      },
+      "payee": {
+        "name": "JENNIFER DESCHRYVER INC",
+        "npi": "1932382397",
+        "address": {
+          "street_line_1": null,
+          "street_line_2": null,
+          "city": "BLOOMFLD HLS",
+          "state": "MI",
+          "zip": "483013068"
+        },
+        "additional_ids": [
+          {
+            "type_code": "TJ",
+            "type_label": "Federal Taxpayer's Identification Number",
+            "value": "123123123"
+          }
+        ],
+        "adjustments": [],
+        "delivery_method": null
+      },
+      "patient": {
+        "first_name": "*****MIN",
+        "last_name": "*****LIN",
+        "middle_name": "J",
+        "id": "*******890"
+      },
+      "corrected_patient": {
+        "first_name": null,
+        "last_name": null,
+        "middle_name": null,
+        "id": null
+      },
+      "other_patient": {
+        "first_name": null,
+        "last_name": null,
+        "middle_name": null,
+        "id": null
+      },
+      "service_provider": null,
+      "claim": {
+        "control_number": "26160262372500710",
+        "received_date": "2016-04-15",
+        "expiration_date": null,
+        "filing_indicator_type": "12",
+        "filing_indicator_label": "Preferred Provider Organization (PPO)",
+        "place_of_service": "11",
+        "frequency": "1",
+        "responsibility_sequence": "primary",
+        "status": [
+          "processed"
+        ],
+        "drg_code": null,
+        "drg_quantity": null,
+        "amount": {
+          "billed": 435,
+          "paid": 33.7,
+          "patient_responsibility": 260,
+          "total_coverage": 298.68,
+          "prompt_payment_discount": null,
+          "per_day_limit": null,
+          "patient_paid": null,
+          "revised_interest": null,
+          "negative_ledger_balance": null,
+          "tax": null,
+          "total_claim_before_taxes": null,
+          "federal": {
+            "category_1": null,
+            "category_2": null,
+            "category_3": null,
+            "category_4": null,
+            "category_5": null
+          }
+        },
+        "adjustments": [],
+        "quantity": {
+          "actual": {
+            "covered": null,
+            "co_insured": null,
+            "life_time_reserve": null
+          },
+          "estimated": {
+            "life_time_reserve": null,
+            "non_covered": null
+          },
+          "not_replaced_blood_unit": null,
+          "outlier_days": null,
+          "prescription": null,
+          "visits": null,
+          "federal": {
+            "category_1": null,
+            "category_2": null,
+            "category_3": null,
+            "category_4": null,
+            "category_5": null
+          }
+        },
+        "additional_ids": [],
+        "rendering_provider_ids": [],
+        "moa_codes": [],
+        "allowed_amount": 298.68,
+        "contacts": [],
+        "service_lines": [
+          {
+            "procedure_qualifier": "HC<90834",
+            "procedure_code": null,
+            "procedure_modifiers": [],
+            "revenue_code": "",
+            "service_start": "2016-04-15",
+            "service_end": "2016-04-15",
+            "amount": {
+              "billed": 145,
+              "paid": 0,
+              "total_coverage": 99.56,
+              "deduction": null,
+              "tax": null,
+              "total_claim_before_taxes": null,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "quantity": {
+              "billed": 0,
+              "paid": 1,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "additional_ids": [],
+            "rendering_provider_ids": [],
+            "allowed_amount": 99.56,
+            "remark_codes": [],
+            "provider_control_number": "123123123",
+            "healthcare_policy": [],
+            "adjustments": [
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "1",
+                "reason_label": "Deductible Amount",
+                "amount": 79.56,
+                "quantity": 0
+              },
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "3",
+                "reason_label": "Co-payment Amount",
+                "amount": 20,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "45",
+                "reason_label": "Charge exceeds fee schedule/maximum allowable or contracted/legislated fee arrangement. (Use only with Group Codes PR or CO depending upon liability)",
+                "amount": 45.44,
+                "quantity": 0
+              }
+            ]
+          },
+          {
+            "procedure_qualifier": "HC<90834",
+            "procedure_code": null,
+            "procedure_modifiers": [],
+            "revenue_code": "",
+            "service_start": "2016-04-15",
+            "service_end": "2016-04-15",
+            "amount": {
+              "billed": 145,
+              "paid": 0,
+              "total_coverage": 99.56,
+              "deduction": null,
+              "tax": null,
+              "total_claim_before_taxes": null,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "quantity": {
+              "billed": 0,
+              "paid": 1,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "additional_ids": [],
+            "rendering_provider_ids": [],
+            "allowed_amount": 99.56,
+            "remark_codes": [],
+            "provider_control_number": "123123123",
+            "healthcare_policy": [],
+            "adjustments": [
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "1",
+                "reason_label": "Deductible Amount",
+                "amount": 79.56,
+                "quantity": 0
+              },
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "3",
+                "reason_label": "Co-payment Amount",
+                "amount": 20,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "45",
+                "reason_label": "Charge exceeds fee schedule/maximum allowable or contracted/legislated fee arrangement. (Use only with Group Codes PR or CO depending upon liability)",
+                "amount": 45.44,
+                "quantity": 0
+              }
+            ]
+          },
+          {
+            "procedure_qualifier": "HC<90834",
+            "procedure_code": null,
+            "procedure_modifiers": [],
+            "revenue_code": "",
+            "service_start": "2016-04-15",
+            "service_end": "2016-04-15",
+            "amount": {
+              "billed": 145,
+              "paid": 33.7,
+              "total_coverage": 99.56,
+              "deduction": null,
+              "tax": null,
+              "total_claim_before_taxes": null,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "quantity": {
+              "billed": 0,
+              "paid": 1,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "additional_ids": [],
+            "rendering_provider_ids": [],
+            "allowed_amount": 99.56,
+            "remark_codes": [],
+            "provider_control_number": "123123123",
+            "healthcare_policy": [],
+            "adjustments": [
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "1",
+                "reason_label": "Deductible Amount",
+                "amount": 40.88,
+                "quantity": 0
+              },
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "3",
+                "reason_label": "Co-payment Amount",
+                "amount": 20,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "144",
+                "reason_label": "Incentive adjustment, e.g. preferred product/service.",
+                "amount": 4.98,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "45",
+                "reason_label": "Charge exceeds fee schedule/maximum allowable or contracted/legislated fee arrangement. (Use only with Group Codes PR or CO depending upon liability)",
+                "amount": 45.44,
+                "quantity": 0
+              }
+            ]
+          }
+        ]
+      },
+      "reference_id": "8KA3FBX3HXBCKZ"
+    },
+    {
+      "effective_date": "2016-04-15",
+      "payer": {
+        "name": "BCBSM",
+        "id": "ELIG_SNDBX",
+        "address": {
+          "street_line_1": "600 E LAFAYETTE",
+          "street_line_2": null,
+          "city": "DETROIT",
+          "state": "MI",
+          "zip": "482260000"
+        },
+        "contacts": [
+          {
+            "department_code": "CX",
+            "department_label": "Payers Claim Office. Location responsible for paying bills related to medical care received",
+            "name": "EDI HELPDESK",
+            "details": [
+              {
+                "type_code": "TE",
+                "type_label": "Telephone",
+                "value": "8005420945"
+              },
+              {
+                "type_code": "FX",
+                "type_label": "Facsimile",
+                "value": "2484862453"
+              }
+            ]
+          },
+          {
+            "department_code": "BL",
+            "department_label": "Technical Department",
+            "name": "EDI HELPDESK",
+            "details": [
+              {
+                "type_code": "TE",
+                "type_label": "Telephone",
+                "value": "8005420945"
+              },
+              {
+                "type_code": "FX",
+                "type_label": "Facsimile",
+                "value": "2484862453"
+              },
+              {
+                "type_code": "EM",
+                "type_label": "Electronic Mail",
+                "value": "EDI@BCBSM.COM"
+              }
+            ]
+          }
+        ],
+        "crossover_payer": null,
+        "corrected_priority_payer": null
+      },
+      "financials": {
+        "type_code": "I",
+        "type_label": "Remittance Information Only",
+        "total_payment_amount": "1261.03",
+        "credit": true,
+        "debit": false,
+        "payment_method_code": "ACH",
+        "payment_method_label": "Automated Clearing House (ACH)",
+        "payment_format_code": "CCP",
+        "payment_format_label": "Cash Concentration/Disbursement plus Addenda (CCD+) (ACH)",
+        "payment_date": "2016-02-03",
+        "payment_trace_number": "710618145",
+        "sender": {
+          "dfi_id_qualifier": "01",
+          "dfi_id_qualifier_label": "ABA Transit Routing Number Including Check Digits (9 digits)",
+          "dfi_id": "091000019",
+          "account_number": "1382069753",
+          "id": "1382069753",
+          "supplemental_code": ""
+        },
+        "receiver": {
+          "dfi_id_qualifier": "01",
+          "dfi_id_qualifier_label": "ABA Transit Routing Number Including Check Digits (9 digits)",
+          "dfi_id": "072000096",
+          "account_type": "Demand Deposit",
+          "account_number": "1852205283"
+        }
+      },
+      "payee": {
+        "name": "JENNIFER DESCHRYVER INC",
+        "npi": "1932382397",
+        "address": {
+          "street_line_1": null,
+          "street_line_2": null,
+          "city": "BLOOMFLD HLS",
+          "state": "MI",
+          "zip": "483013068"
+        },
+        "additional_ids": [
+          {
+            "type_code": "TJ",
+            "type_label": "Federal Taxpayer's Identification Number",
+            "value": "123123123"
+          }
+        ],
+        "adjustments": [],
+        "delivery_method": null
+      },
+      "patient": {
+        "first_name": "*****MIN",
+        "last_name": "*****LIN",
+        "middle_name": "J",
+        "id": "*******890"
+      },
+      "corrected_patient": {
+        "first_name": null,
+        "last_name": null,
+        "middle_name": null,
+        "id": null
+      },
+      "other_patient": {
+        "first_name": null,
+        "last_name": null,
+        "middle_name": null,
+        "id": null
+      },
+      "service_provider": null,
+      "claim": {
+        "control_number": "26160262372500710",
+        "received_date": "2016-04-15",
+        "expiration_date": null,
+        "filing_indicator_type": "12",
+        "filing_indicator_label": "Preferred Provider Organization (PPO)",
+        "place_of_service": "11",
+        "frequency": "1",
+        "responsibility_sequence": "primary",
+        "status": [
+          "processed"
+        ],
+        "drg_code": null,
+        "drg_quantity": null,
+        "amount": {
+          "billed": 435,
+          "paid": 33.7,
+          "patient_responsibility": 260,
+          "total_coverage": 298.68,
+          "prompt_payment_discount": null,
+          "per_day_limit": null,
+          "patient_paid": null,
+          "revised_interest": null,
+          "negative_ledger_balance": null,
+          "tax": null,
+          "total_claim_before_taxes": null,
+          "federal": {
+            "category_1": null,
+            "category_2": null,
+            "category_3": null,
+            "category_4": null,
+            "category_5": null
+          }
+        },
+        "adjustments": [],
+        "quantity": {
+          "actual": {
+            "covered": null,
+            "co_insured": null,
+            "life_time_reserve": null
+          },
+          "estimated": {
+            "life_time_reserve": null,
+            "non_covered": null
+          },
+          "not_replaced_blood_unit": null,
+          "outlier_days": null,
+          "prescription": null,
+          "visits": null,
+          "federal": {
+            "category_1": null,
+            "category_2": null,
+            "category_3": null,
+            "category_4": null,
+            "category_5": null
+          }
+        },
+        "additional_ids": [],
+        "rendering_provider_ids": [],
+        "moa_codes": [],
+        "allowed_amount": 298.68,
+        "contacts": [],
+        "service_lines": [
+          {
+            "procedure_qualifier": "HC<90834",
+            "procedure_code": null,
+            "procedure_modifiers": [],
+            "revenue_code": "",
+            "service_start": "2016-04-15",
+            "service_end": "2016-04-15",
+            "amount": {
+              "billed": 145,
+              "paid": 0,
+              "total_coverage": 99.56,
+              "deduction": null,
+              "tax": null,
+              "total_claim_before_taxes": null,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "quantity": {
+              "billed": 0,
+              "paid": 1,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "additional_ids": [],
+            "rendering_provider_ids": [],
+            "allowed_amount": 99.56,
+            "remark_codes": [],
+            "provider_control_number": "123123123",
+            "healthcare_policy": [],
+            "adjustments": [
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "1",
+                "reason_label": "Deductible Amount",
+                "amount": 79.56,
+                "quantity": 0
+              },
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "3",
+                "reason_label": "Co-payment Amount",
+                "amount": 20,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "45",
+                "reason_label": "Charge exceeds fee schedule/maximum allowable or contracted/legislated fee arrangement. (Use only with Group Codes PR or CO depending upon liability)",
+                "amount": 45.44,
+                "quantity": 0
+              }
+            ]
+          },
+          {
+            "procedure_qualifier": "HC<90834",
+            "procedure_code": null,
+            "procedure_modifiers": [],
+            "revenue_code": "",
+            "service_start": "2016-04-15",
+            "service_end": "2016-04-15",
+            "amount": {
+              "billed": 145,
+              "paid": 0,
+              "total_coverage": 99.56,
+              "deduction": null,
+              "tax": null,
+              "total_claim_before_taxes": null,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "quantity": {
+              "billed": 0,
+              "paid": 1,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "additional_ids": [],
+            "rendering_provider_ids": [],
+            "allowed_amount": 99.56,
+            "remark_codes": [],
+            "provider_control_number": "123123123",
+            "healthcare_policy": [],
+            "adjustments": [
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "1",
+                "reason_label": "Deductible Amount",
+                "amount": 79.56,
+                "quantity": 0
+              },
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "3",
+                "reason_label": "Co-payment Amount",
+                "amount": 20,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "45",
+                "reason_label": "Charge exceeds fee schedule/maximum allowable or contracted/legislated fee arrangement. (Use only with Group Codes PR or CO depending upon liability)",
+                "amount": 45.44,
+                "quantity": 0
+              }
+            ]
+          },
+          {
+            "procedure_qualifier": "HC<90834",
+            "procedure_code": null,
+            "procedure_modifiers": [],
+            "revenue_code": "",
+            "service_start": "2016-04-15",
+            "service_end": "2016-04-15",
+            "amount": {
+              "billed": 145,
+              "paid": 33.7,
+              "total_coverage": 99.56,
+              "deduction": null,
+              "tax": null,
+              "total_claim_before_taxes": null,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "quantity": {
+              "billed": 0,
+              "paid": 1,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "additional_ids": [],
+            "rendering_provider_ids": [],
+            "allowed_amount": 99.56,
+            "remark_codes": [],
+            "provider_control_number": "123123123",
+            "healthcare_policy": [],
+            "adjustments": [
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "1",
+                "reason_label": "Deductible Amount",
+                "amount": 40.88,
+                "quantity": 0
+              },
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "3",
+                "reason_label": "Co-payment Amount",
+                "amount": 20,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "144",
+                "reason_label": "Incentive adjustment, e.g. preferred product/service.",
+                "amount": 4.98,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "45",
+                "reason_label": "Charge exceeds fee schedule/maximum allowable or contracted/legislated fee arrangement. (Use only with Group Codes PR or CO depending upon liability)",
+                "amount": 45.44,
+                "quantity": 0
+              }
+            ]
+          }
+        ]
+      },
+      "reference_id": "8KA3FBX3HXBCKZ"
+    },
+    {
+      "effective_date": "2016-04-15",
+      "payer": {
+        "name": "BCBSM",
+        "id": "ELIG_SNDBX",
+        "address": {
+          "street_line_1": "600 E LAFAYETTE",
+          "street_line_2": null,
+          "city": "DETROIT",
+          "state": "MI",
+          "zip": "482260000"
+        },
+        "contacts": [
+          {
+            "department_code": "CX",
+            "department_label": "Payers Claim Office. Location responsible for paying bills related to medical care received",
+            "name": "EDI HELPDESK",
+            "details": [
+              {
+                "type_code": "TE",
+                "type_label": "Telephone",
+                "value": "8005420945"
+              },
+              {
+                "type_code": "FX",
+                "type_label": "Facsimile",
+                "value": "2484862453"
+              }
+            ]
+          },
+          {
+            "department_code": "BL",
+            "department_label": "Technical Department",
+            "name": "EDI HELPDESK",
+            "details": [
+              {
+                "type_code": "TE",
+                "type_label": "Telephone",
+                "value": "8005420945"
+              },
+              {
+                "type_code": "FX",
+                "type_label": "Facsimile",
+                "value": "2484862453"
+              },
+              {
+                "type_code": "EM",
+                "type_label": "Electronic Mail",
+                "value": "EDI@BCBSM.COM"
+              }
+            ]
+          }
+        ],
+        "crossover_payer": null,
+        "corrected_priority_payer": null
+      },
+      "financials": {
+        "type_code": "I",
+        "type_label": "Remittance Information Only",
+        "total_payment_amount": "1261.03",
+        "credit": true,
+        "debit": false,
+        "payment_method_code": "ACH",
+        "payment_method_label": "Automated Clearing House (ACH)",
+        "payment_format_code": "CCP",
+        "payment_format_label": "Cash Concentration/Disbursement plus Addenda (CCD+) (ACH)",
+        "payment_date": "2016-02-03",
+        "payment_trace_number": "710618145",
+        "sender": {
+          "dfi_id_qualifier": "01",
+          "dfi_id_qualifier_label": "ABA Transit Routing Number Including Check Digits (9 digits)",
+          "dfi_id": "091000019",
+          "account_number": "1382069753",
+          "id": "1382069753",
+          "supplemental_code": ""
+        },
+        "receiver": {
+          "dfi_id_qualifier": "01",
+          "dfi_id_qualifier_label": "ABA Transit Routing Number Including Check Digits (9 digits)",
+          "dfi_id": "072000096",
+          "account_type": "Demand Deposit",
+          "account_number": "1852205283"
+        }
+      },
+      "payee": {
+        "name": "JENNIFER DESCHRYVER INC",
+        "npi": "1932382397",
+        "address": {
+          "street_line_1": null,
+          "street_line_2": null,
+          "city": "BLOOMFLD HLS",
+          "state": "MI",
+          "zip": "483013068"
+        },
+        "additional_ids": [
+          {
+            "type_code": "TJ",
+            "type_label": "Federal Taxpayer's Identification Number",
+            "value": "123123123"
+          }
+        ],
+        "adjustments": [],
+        "delivery_method": null
+      },
+      "patient": {
+        "first_name": "*****MIN",
+        "last_name": "*****LIN",
+        "middle_name": "J",
+        "id": "*******890"
+      },
+      "corrected_patient": {
+        "first_name": null,
+        "last_name": null,
+        "middle_name": null,
+        "id": null
+      },
+      "other_patient": {
+        "first_name": null,
+        "last_name": null,
+        "middle_name": null,
+        "id": null
+      },
+      "service_provider": null,
+      "claim": {
+        "control_number": "26160262372500710",
+        "received_date": "2016-04-15",
+        "expiration_date": null,
+        "filing_indicator_type": "12",
+        "filing_indicator_label": "Preferred Provider Organization (PPO)",
+        "place_of_service": "11",
+        "frequency": "1",
+        "responsibility_sequence": "primary",
+        "status": [
+          "processed"
+        ],
+        "drg_code": null,
+        "drg_quantity": null,
+        "amount": {
+          "billed": 435,
+          "paid": 33.7,
+          "patient_responsibility": 260,
+          "total_coverage": 298.68,
+          "prompt_payment_discount": null,
+          "per_day_limit": null,
+          "patient_paid": null,
+          "revised_interest": null,
+          "negative_ledger_balance": null,
+          "tax": null,
+          "total_claim_before_taxes": null,
+          "federal": {
+            "category_1": null,
+            "category_2": null,
+            "category_3": null,
+            "category_4": null,
+            "category_5": null
+          }
+        },
+        "adjustments": [],
+        "quantity": {
+          "actual": {
+            "covered": null,
+            "co_insured": null,
+            "life_time_reserve": null
+          },
+          "estimated": {
+            "life_time_reserve": null,
+            "non_covered": null
+          },
+          "not_replaced_blood_unit": null,
+          "outlier_days": null,
+          "prescription": null,
+          "visits": null,
+          "federal": {
+            "category_1": null,
+            "category_2": null,
+            "category_3": null,
+            "category_4": null,
+            "category_5": null
+          }
+        },
+        "additional_ids": [],
+        "rendering_provider_ids": [],
+        "moa_codes": [],
+        "allowed_amount": 298.68,
+        "contacts": [],
+        "service_lines": [
+          {
+            "procedure_qualifier": "HC<90834",
+            "procedure_code": null,
+            "procedure_modifiers": [],
+            "revenue_code": "",
+            "service_start": "2016-04-15",
+            "service_end": "2016-04-15",
+            "amount": {
+              "billed": 145,
+              "paid": 0,
+              "total_coverage": 99.56,
+              "deduction": null,
+              "tax": null,
+              "total_claim_before_taxes": null,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "quantity": {
+              "billed": 0,
+              "paid": 1,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "additional_ids": [],
+            "rendering_provider_ids": [],
+            "allowed_amount": 99.56,
+            "remark_codes": [],
+            "provider_control_number": "123123123",
+            "healthcare_policy": [],
+            "adjustments": [
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "1",
+                "reason_label": "Deductible Amount",
+                "amount": 79.56,
+                "quantity": 0
+              },
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "3",
+                "reason_label": "Co-payment Amount",
+                "amount": 20,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "45",
+                "reason_label": "Charge exceeds fee schedule/maximum allowable or contracted/legislated fee arrangement. (Use only with Group Codes PR or CO depending upon liability)",
+                "amount": 45.44,
+                "quantity": 0
+              }
+            ]
+          },
+          {
+            "procedure_qualifier": "HC<90834",
+            "procedure_code": null,
+            "procedure_modifiers": [],
+            "revenue_code": "",
+            "service_start": "2016-04-15",
+            "service_end": "2016-04-15",
+            "amount": {
+              "billed": 145,
+              "paid": 0,
+              "total_coverage": 99.56,
+              "deduction": null,
+              "tax": null,
+              "total_claim_before_taxes": null,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "quantity": {
+              "billed": 0,
+              "paid": 1,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "additional_ids": [],
+            "rendering_provider_ids": [],
+            "allowed_amount": 99.56,
+            "remark_codes": [],
+            "provider_control_number": "123123123",
+            "healthcare_policy": [],
+            "adjustments": [
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "1",
+                "reason_label": "Deductible Amount",
+                "amount": 79.56,
+                "quantity": 0
+              },
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "3",
+                "reason_label": "Co-payment Amount",
+                "amount": 20,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "45",
+                "reason_label": "Charge exceeds fee schedule/maximum allowable or contracted/legislated fee arrangement. (Use only with Group Codes PR or CO depending upon liability)",
+                "amount": 45.44,
+                "quantity": 0
+              }
+            ]
+          },
+          {
+            "procedure_qualifier": "HC<90834",
+            "procedure_code": null,
+            "procedure_modifiers": [],
+            "revenue_code": "",
+            "service_start": "2016-04-15",
+            "service_end": "2016-04-15",
+            "amount": {
+              "billed": 145,
+              "paid": 33.7,
+              "total_coverage": 99.56,
+              "deduction": null,
+              "tax": null,
+              "total_claim_before_taxes": null,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "quantity": {
+              "billed": 0,
+              "paid": 1,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "additional_ids": [],
+            "rendering_provider_ids": [],
+            "allowed_amount": 99.56,
+            "remark_codes": [],
+            "provider_control_number": "123123123",
+            "healthcare_policy": [],
+            "adjustments": [
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "1",
+                "reason_label": "Deductible Amount",
+                "amount": 40.88,
+                "quantity": 0
+              },
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "3",
+                "reason_label": "Co-payment Amount",
+                "amount": 20,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "144",
+                "reason_label": "Incentive adjustment, e.g. preferred product/service.",
+                "amount": 4.98,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "45",
+                "reason_label": "Charge exceeds fee schedule/maximum allowable or contracted/legislated fee arrangement. (Use only with Group Codes PR or CO depending upon liability)",
+                "amount": 45.44,
+                "quantity": 0
+              }
+            ]
+          }
+        ]
+      },
+      "reference_id": "8KA1O0SFD6A29N"
+    },
+    {
+      "effective_date": "2016-04-15",
+      "payer": {
+        "name": "BCBSM",
+        "id": "ELIG_SNDBX",
+        "address": {
+          "street_line_1": "600 E LAFAYETTE",
+          "street_line_2": null,
+          "city": "DETROIT",
+          "state": "MI",
+          "zip": "482260000"
+        },
+        "contacts": [
+          {
+            "department_code": "CX",
+            "department_label": "Payers Claim Office. Location responsible for paying bills related to medical care received",
+            "name": "EDI HELPDESK",
+            "details": [
+              {
+                "type_code": "TE",
+                "type_label": "Telephone",
+                "value": "8005420945"
+              },
+              {
+                "type_code": "FX",
+                "type_label": "Facsimile",
+                "value": "2484862453"
+              }
+            ]
+          },
+          {
+            "department_code": "BL",
+            "department_label": "Technical Department",
+            "name": "EDI HELPDESK",
+            "details": [
+              {
+                "type_code": "TE",
+                "type_label": "Telephone",
+                "value": "8005420945"
+              },
+              {
+                "type_code": "FX",
+                "type_label": "Facsimile",
+                "value": "2484862453"
+              },
+              {
+                "type_code": "EM",
+                "type_label": "Electronic Mail",
+                "value": "EDI@BCBSM.COM"
+              }
+            ]
+          }
+        ],
+        "crossover_payer": null,
+        "corrected_priority_payer": null
+      },
+      "financials": {
+        "type_code": "I",
+        "type_label": "Remittance Information Only",
+        "total_payment_amount": "1261.03",
+        "credit": true,
+        "debit": false,
+        "payment_method_code": "ACH",
+        "payment_method_label": "Automated Clearing House (ACH)",
+        "payment_format_code": "CCP",
+        "payment_format_label": "Cash Concentration/Disbursement plus Addenda (CCD+) (ACH)",
+        "payment_date": "2016-02-03",
+        "payment_trace_number": "710618145",
+        "sender": {
+          "dfi_id_qualifier": "01",
+          "dfi_id_qualifier_label": "ABA Transit Routing Number Including Check Digits (9 digits)",
+          "dfi_id": "091000019",
+          "account_number": "1382069753",
+          "id": "1382069753",
+          "supplemental_code": ""
+        },
+        "receiver": {
+          "dfi_id_qualifier": "01",
+          "dfi_id_qualifier_label": "ABA Transit Routing Number Including Check Digits (9 digits)",
+          "dfi_id": "072000096",
+          "account_type": "Demand Deposit",
+          "account_number": "1852205283"
+        }
+      },
+      "payee": {
+        "name": "JENNIFER DESCHRYVER INC",
+        "npi": "1932382397",
+        "address": {
+          "street_line_1": null,
+          "street_line_2": null,
+          "city": "BLOOMFLD HLS",
+          "state": "MI",
+          "zip": "483013068"
+        },
+        "additional_ids": [
+          {
+            "type_code": "TJ",
+            "type_label": "Federal Taxpayer's Identification Number",
+            "value": "123123123"
+          }
+        ],
+        "adjustments": [],
+        "delivery_method": null
+      },
+      "patient": {
+        "first_name": "*****MIN",
+        "last_name": "*****LIN",
+        "middle_name": "J",
+        "id": "*******890"
+      },
+      "corrected_patient": {
+        "first_name": null,
+        "last_name": null,
+        "middle_name": null,
+        "id": null
+      },
+      "other_patient": {
+        "first_name": null,
+        "last_name": null,
+        "middle_name": null,
+        "id": null
+      },
+      "service_provider": null,
+      "claim": {
+        "control_number": "26160262372500710",
+        "received_date": "2016-04-15",
+        "expiration_date": null,
+        "filing_indicator_type": "12",
+        "filing_indicator_label": "Preferred Provider Organization (PPO)",
+        "place_of_service": "11",
+        "frequency": "1",
+        "responsibility_sequence": "primary",
+        "status": [
+          "processed"
+        ],
+        "drg_code": null,
+        "drg_quantity": null,
+        "amount": {
+          "billed": 435,
+          "paid": 33.7,
+          "patient_responsibility": 260,
+          "total_coverage": 298.68,
+          "prompt_payment_discount": null,
+          "per_day_limit": null,
+          "patient_paid": null,
+          "revised_interest": null,
+          "negative_ledger_balance": null,
+          "tax": null,
+          "total_claim_before_taxes": null,
+          "federal": {
+            "category_1": null,
+            "category_2": null,
+            "category_3": null,
+            "category_4": null,
+            "category_5": null
+          }
+        },
+        "adjustments": [],
+        "quantity": {
+          "actual": {
+            "covered": null,
+            "co_insured": null,
+            "life_time_reserve": null
+          },
+          "estimated": {
+            "life_time_reserve": null,
+            "non_covered": null
+          },
+          "not_replaced_blood_unit": null,
+          "outlier_days": null,
+          "prescription": null,
+          "visits": null,
+          "federal": {
+            "category_1": null,
+            "category_2": null,
+            "category_3": null,
+            "category_4": null,
+            "category_5": null
+          }
+        },
+        "additional_ids": [],
+        "rendering_provider_ids": [],
+        "moa_codes": [],
+        "allowed_amount": 298.68,
+        "contacts": [],
+        "service_lines": [
+          {
+            "procedure_qualifier": "HC<90834",
+            "procedure_code": null,
+            "procedure_modifiers": [],
+            "revenue_code": "",
+            "service_start": "2016-04-15",
+            "service_end": "2016-04-15",
+            "amount": {
+              "billed": 145,
+              "paid": 0,
+              "total_coverage": 99.56,
+              "deduction": null,
+              "tax": null,
+              "total_claim_before_taxes": null,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "quantity": {
+              "billed": 0,
+              "paid": 1,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "additional_ids": [],
+            "rendering_provider_ids": [],
+            "allowed_amount": 99.56,
+            "remark_codes": [],
+            "provider_control_number": "123123123",
+            "healthcare_policy": [],
+            "adjustments": [
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "1",
+                "reason_label": "Deductible Amount",
+                "amount": 79.56,
+                "quantity": 0
+              },
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "3",
+                "reason_label": "Co-payment Amount",
+                "amount": 20,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "45",
+                "reason_label": "Charge exceeds fee schedule/maximum allowable or contracted/legislated fee arrangement. (Use only with Group Codes PR or CO depending upon liability)",
+                "amount": 45.44,
+                "quantity": 0
+              }
+            ]
+          },
+          {
+            "procedure_qualifier": "HC<90834",
+            "procedure_code": null,
+            "procedure_modifiers": [],
+            "revenue_code": "",
+            "service_start": "2016-04-15",
+            "service_end": "2016-04-15",
+            "amount": {
+              "billed": 145,
+              "paid": 0,
+              "total_coverage": 99.56,
+              "deduction": null,
+              "tax": null,
+              "total_claim_before_taxes": null,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "quantity": {
+              "billed": 0,
+              "paid": 1,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "additional_ids": [],
+            "rendering_provider_ids": [],
+            "allowed_amount": 99.56,
+            "remark_codes": [],
+            "provider_control_number": "123123123",
+            "healthcare_policy": [],
+            "adjustments": [
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "1",
+                "reason_label": "Deductible Amount",
+                "amount": 79.56,
+                "quantity": 0
+              },
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "3",
+                "reason_label": "Co-payment Amount",
+                "amount": 20,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "45",
+                "reason_label": "Charge exceeds fee schedule/maximum allowable or contracted/legislated fee arrangement. (Use only with Group Codes PR or CO depending upon liability)",
+                "amount": 45.44,
+                "quantity": 0
+              }
+            ]
+          },
+          {
+            "procedure_qualifier": "HC<90834",
+            "procedure_code": null,
+            "procedure_modifiers": [],
+            "revenue_code": "",
+            "service_start": "2016-04-15",
+            "service_end": "2016-04-15",
+            "amount": {
+              "billed": 145,
+              "paid": 33.7,
+              "total_coverage": 99.56,
+              "deduction": null,
+              "tax": null,
+              "total_claim_before_taxes": null,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "quantity": {
+              "billed": 0,
+              "paid": 1,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "additional_ids": [],
+            "rendering_provider_ids": [],
+            "allowed_amount": 99.56,
+            "remark_codes": [],
+            "provider_control_number": "123123123",
+            "healthcare_policy": [],
+            "adjustments": [
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "1",
+                "reason_label": "Deductible Amount",
+                "amount": 40.88,
+                "quantity": 0
+              },
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "3",
+                "reason_label": "Co-payment Amount",
+                "amount": 20,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "144",
+                "reason_label": "Incentive adjustment, e.g. preferred product/service.",
+                "amount": 4.98,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "45",
+                "reason_label": "Charge exceeds fee schedule/maximum allowable or contracted/legislated fee arrangement. (Use only with Group Codes PR or CO depending upon liability)",
+                "amount": 45.44,
+                "quantity": 0
+              }
+            ]
+          }
+        ]
+      },
+      "reference_id": "8KA1O0SFD6A29N"
+    },
+    {
+      "effective_date": "2016-04-15",
+      "payer": {
+        "name": "BCBSM",
+        "id": "ELIG_SNDBX",
+        "address": {
+          "street_line_1": "600 E LAFAYETTE",
+          "street_line_2": null,
+          "city": "DETROIT",
+          "state": "MI",
+          "zip": "482260000"
+        },
+        "contacts": [
+          {
+            "department_code": "CX",
+            "department_label": "Payers Claim Office. Location responsible for paying bills related to medical care received",
+            "name": "EDI HELPDESK",
+            "details": [
+              {
+                "type_code": "TE",
+                "type_label": "Telephone",
+                "value": "8005420945"
+              },
+              {
+                "type_code": "FX",
+                "type_label": "Facsimile",
+                "value": "2484862453"
+              }
+            ]
+          },
+          {
+            "department_code": "BL",
+            "department_label": "Technical Department",
+            "name": "EDI HELPDESK",
+            "details": [
+              {
+                "type_code": "TE",
+                "type_label": "Telephone",
+                "value": "8005420945"
+              },
+              {
+                "type_code": "FX",
+                "type_label": "Facsimile",
+                "value": "2484862453"
+              },
+              {
+                "type_code": "EM",
+                "type_label": "Electronic Mail",
+                "value": "EDI@BCBSM.COM"
+              }
+            ]
+          }
+        ],
+        "crossover_payer": null,
+        "corrected_priority_payer": null
+      },
+      "financials": {
+        "type_code": "I",
+        "type_label": "Remittance Information Only",
+        "total_payment_amount": "1261.03",
+        "credit": true,
+        "debit": false,
+        "payment_method_code": "ACH",
+        "payment_method_label": "Automated Clearing House (ACH)",
+        "payment_format_code": "CCP",
+        "payment_format_label": "Cash Concentration/Disbursement plus Addenda (CCD+) (ACH)",
+        "payment_date": "2016-02-03",
+        "payment_trace_number": "710618145",
+        "sender": {
+          "dfi_id_qualifier": "01",
+          "dfi_id_qualifier_label": "ABA Transit Routing Number Including Check Digits (9 digits)",
+          "dfi_id": "091000019",
+          "account_number": "1382069753",
+          "id": "1382069753",
+          "supplemental_code": ""
+        },
+        "receiver": {
+          "dfi_id_qualifier": "01",
+          "dfi_id_qualifier_label": "ABA Transit Routing Number Including Check Digits (9 digits)",
+          "dfi_id": "072000096",
+          "account_type": "Demand Deposit",
+          "account_number": "1852205283"
+        }
+      },
+      "payee": {
+        "name": "JENNIFER DESCHRYVER INC",
+        "npi": "1932382397",
+        "address": {
+          "street_line_1": null,
+          "street_line_2": null,
+          "city": "BLOOMFLD HLS",
+          "state": "MI",
+          "zip": "483013068"
+        },
+        "additional_ids": [
+          {
+            "type_code": "TJ",
+            "type_label": "Federal Taxpayer's Identification Number",
+            "value": "123123123"
+          }
+        ],
+        "adjustments": [],
+        "delivery_method": null
+      },
+      "patient": {
+        "first_name": "*****MIN",
+        "last_name": "*****LIN",
+        "middle_name": "J",
+        "id": "*******890"
+      },
+      "corrected_patient": {
+        "first_name": null,
+        "last_name": null,
+        "middle_name": null,
+        "id": null
+      },
+      "other_patient": {
+        "first_name": null,
+        "last_name": null,
+        "middle_name": null,
+        "id": null
+      },
+      "service_provider": null,
+      "claim": {
+        "control_number": "26160262372500710",
+        "received_date": "2016-04-15",
+        "expiration_date": null,
+        "filing_indicator_type": "12",
+        "filing_indicator_label": "Preferred Provider Organization (PPO)",
+        "place_of_service": "11",
+        "frequency": "1",
+        "responsibility_sequence": "primary",
+        "status": [
+          "processed"
+        ],
+        "drg_code": null,
+        "drg_quantity": null,
+        "amount": {
+          "billed": 435,
+          "paid": 33.7,
+          "patient_responsibility": 260,
+          "total_coverage": 298.68,
+          "prompt_payment_discount": null,
+          "per_day_limit": null,
+          "patient_paid": null,
+          "revised_interest": null,
+          "negative_ledger_balance": null,
+          "tax": null,
+          "total_claim_before_taxes": null,
+          "federal": {
+            "category_1": null,
+            "category_2": null,
+            "category_3": null,
+            "category_4": null,
+            "category_5": null
+          }
+        },
+        "adjustments": [],
+        "quantity": {
+          "actual": {
+            "covered": null,
+            "co_insured": null,
+            "life_time_reserve": null
+          },
+          "estimated": {
+            "life_time_reserve": null,
+            "non_covered": null
+          },
+          "not_replaced_blood_unit": null,
+          "outlier_days": null,
+          "prescription": null,
+          "visits": null,
+          "federal": {
+            "category_1": null,
+            "category_2": null,
+            "category_3": null,
+            "category_4": null,
+            "category_5": null
+          }
+        },
+        "additional_ids": [],
+        "rendering_provider_ids": [],
+        "moa_codes": [],
+        "allowed_amount": 298.68,
+        "contacts": [],
+        "service_lines": [
+          {
+            "procedure_qualifier": "HC<90834",
+            "procedure_code": null,
+            "procedure_modifiers": [],
+            "revenue_code": "",
+            "service_start": "2016-04-15",
+            "service_end": "2016-04-15",
+            "amount": {
+              "billed": 145,
+              "paid": 0,
+              "total_coverage": 99.56,
+              "deduction": null,
+              "tax": null,
+              "total_claim_before_taxes": null,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "quantity": {
+              "billed": 0,
+              "paid": 1,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "additional_ids": [],
+            "rendering_provider_ids": [],
+            "allowed_amount": 99.56,
+            "remark_codes": [],
+            "provider_control_number": "123123123",
+            "healthcare_policy": [],
+            "adjustments": [
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "1",
+                "reason_label": "Deductible Amount",
+                "amount": 79.56,
+                "quantity": 0
+              },
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "3",
+                "reason_label": "Co-payment Amount",
+                "amount": 20,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "45",
+                "reason_label": "Charge exceeds fee schedule/maximum allowable or contracted/legislated fee arrangement. (Use only with Group Codes PR or CO depending upon liability)",
+                "amount": 45.44,
+                "quantity": 0
+              }
+            ]
+          },
+          {
+            "procedure_qualifier": "HC<90834",
+            "procedure_code": null,
+            "procedure_modifiers": [],
+            "revenue_code": "",
+            "service_start": "2016-04-15",
+            "service_end": "2016-04-15",
+            "amount": {
+              "billed": 145,
+              "paid": 0,
+              "total_coverage": 99.56,
+              "deduction": null,
+              "tax": null,
+              "total_claim_before_taxes": null,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "quantity": {
+              "billed": 0,
+              "paid": 1,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "additional_ids": [],
+            "rendering_provider_ids": [],
+            "allowed_amount": 99.56,
+            "remark_codes": [],
+            "provider_control_number": "123123123",
+            "healthcare_policy": [],
+            "adjustments": [
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "1",
+                "reason_label": "Deductible Amount",
+                "amount": 79.56,
+                "quantity": 0
+              },
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "3",
+                "reason_label": "Co-payment Amount",
+                "amount": 20,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "45",
+                "reason_label": "Charge exceeds fee schedule/maximum allowable or contracted/legislated fee arrangement. (Use only with Group Codes PR or CO depending upon liability)",
+                "amount": 45.44,
+                "quantity": 0
+              }
+            ]
+          },
+          {
+            "procedure_qualifier": "HC<90834",
+            "procedure_code": null,
+            "procedure_modifiers": [],
+            "revenue_code": "",
+            "service_start": "2016-04-15",
+            "service_end": "2016-04-15",
+            "amount": {
+              "billed": 145,
+              "paid": 33.7,
+              "total_coverage": 99.56,
+              "deduction": null,
+              "tax": null,
+              "total_claim_before_taxes": null,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "quantity": {
+              "billed": 0,
+              "paid": 1,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "additional_ids": [],
+            "rendering_provider_ids": [],
+            "allowed_amount": 99.56,
+            "remark_codes": [],
+            "provider_control_number": "123123123",
+            "healthcare_policy": [],
+            "adjustments": [
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "1",
+                "reason_label": "Deductible Amount",
+                "amount": 40.88,
+                "quantity": 0
+              },
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "3",
+                "reason_label": "Co-payment Amount",
+                "amount": 20,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "144",
+                "reason_label": "Incentive adjustment, e.g. preferred product/service.",
+                "amount": 4.98,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "45",
+                "reason_label": "Charge exceeds fee schedule/maximum allowable or contracted/legislated fee arrangement. (Use only with Group Codes PR or CO depending upon liability)",
+                "amount": 45.44,
+                "quantity": 0
+              }
+            ]
+          }
+        ]
+      },
+      "reference_id": "8KA1O0SFD6A29N"
+    },
+    {
+      "effective_date": "2016-04-15",
+      "payer": {
+        "name": "BCBSM",
+        "id": "ELIG_SNDBX",
+        "address": {
+          "street_line_1": "600 E LAFAYETTE",
+          "street_line_2": null,
+          "city": "DETROIT",
+          "state": "MI",
+          "zip": "482260000"
+        },
+        "contacts": [
+          {
+            "department_code": "CX",
+            "department_label": "Payers Claim Office. Location responsible for paying bills related to medical care received",
+            "name": "EDI HELPDESK",
+            "details": [
+              {
+                "type_code": "TE",
+                "type_label": "Telephone",
+                "value": "8005420945"
+              },
+              {
+                "type_code": "FX",
+                "type_label": "Facsimile",
+                "value": "2484862453"
+              }
+            ]
+          },
+          {
+            "department_code": "BL",
+            "department_label": "Technical Department",
+            "name": "EDI HELPDESK",
+            "details": [
+              {
+                "type_code": "TE",
+                "type_label": "Telephone",
+                "value": "8005420945"
+              },
+              {
+                "type_code": "FX",
+                "type_label": "Facsimile",
+                "value": "2484862453"
+              },
+              {
+                "type_code": "EM",
+                "type_label": "Electronic Mail",
+                "value": "EDI@BCBSM.COM"
+              }
+            ]
+          }
+        ],
+        "crossover_payer": null,
+        "corrected_priority_payer": null
+      },
+      "financials": {
+        "type_code": "I",
+        "type_label": "Remittance Information Only",
+        "total_payment_amount": "1261.03",
+        "credit": true,
+        "debit": false,
+        "payment_method_code": "ACH",
+        "payment_method_label": "Automated Clearing House (ACH)",
+        "payment_format_code": "CCP",
+        "payment_format_label": "Cash Concentration/Disbursement plus Addenda (CCD+) (ACH)",
+        "payment_date": "2016-02-03",
+        "payment_trace_number": "710618145",
+        "sender": {
+          "dfi_id_qualifier": "01",
+          "dfi_id_qualifier_label": "ABA Transit Routing Number Including Check Digits (9 digits)",
+          "dfi_id": "091000019",
+          "account_number": "1382069753",
+          "id": "1382069753",
+          "supplemental_code": ""
+        },
+        "receiver": {
+          "dfi_id_qualifier": "01",
+          "dfi_id_qualifier_label": "ABA Transit Routing Number Including Check Digits (9 digits)",
+          "dfi_id": "072000096",
+          "account_type": "Demand Deposit",
+          "account_number": "1852205283"
+        }
+      },
+      "payee": {
+        "name": "JENNIFER DESCHRYVER INC",
+        "npi": "1932382397",
+        "address": {
+          "street_line_1": null,
+          "street_line_2": null,
+          "city": "BLOOMFLD HLS",
+          "state": "MI",
+          "zip": "483013068"
+        },
+        "additional_ids": [
+          {
+            "type_code": "TJ",
+            "type_label": "Federal Taxpayer's Identification Number",
+            "value": "123123123"
+          }
+        ],
+        "adjustments": [],
+        "delivery_method": null
+      },
+      "patient": {
+        "first_name": "*****MIN",
+        "last_name": "*****LIN",
+        "middle_name": "J",
+        "id": "*******890"
+      },
+      "corrected_patient": {
+        "first_name": null,
+        "last_name": null,
+        "middle_name": null,
+        "id": null
+      },
+      "other_patient": {
+        "first_name": null,
+        "last_name": null,
+        "middle_name": null,
+        "id": null
+      },
+      "service_provider": null,
+      "claim": {
+        "control_number": "26160262372500710",
+        "received_date": "2016-04-15",
+        "expiration_date": null,
+        "filing_indicator_type": "12",
+        "filing_indicator_label": "Preferred Provider Organization (PPO)",
+        "place_of_service": "11",
+        "frequency": "1",
+        "responsibility_sequence": "primary",
+        "status": [
+          "processed"
+        ],
+        "drg_code": null,
+        "drg_quantity": null,
+        "amount": {
+          "billed": 435,
+          "paid": 33.7,
+          "patient_responsibility": 260,
+          "total_coverage": 298.68,
+          "prompt_payment_discount": null,
+          "per_day_limit": null,
+          "patient_paid": null,
+          "revised_interest": null,
+          "negative_ledger_balance": null,
+          "tax": null,
+          "total_claim_before_taxes": null,
+          "federal": {
+            "category_1": null,
+            "category_2": null,
+            "category_3": null,
+            "category_4": null,
+            "category_5": null
+          }
+        },
+        "adjustments": [],
+        "quantity": {
+          "actual": {
+            "covered": null,
+            "co_insured": null,
+            "life_time_reserve": null
+          },
+          "estimated": {
+            "life_time_reserve": null,
+            "non_covered": null
+          },
+          "not_replaced_blood_unit": null,
+          "outlier_days": null,
+          "prescription": null,
+          "visits": null,
+          "federal": {
+            "category_1": null,
+            "category_2": null,
+            "category_3": null,
+            "category_4": null,
+            "category_5": null
+          }
+        },
+        "additional_ids": [],
+        "rendering_provider_ids": [],
+        "moa_codes": [],
+        "allowed_amount": 298.68,
+        "contacts": [],
+        "service_lines": [
+          {
+            "procedure_qualifier": "HC<90834",
+            "procedure_code": null,
+            "procedure_modifiers": [],
+            "revenue_code": "",
+            "service_start": "2016-04-15",
+            "service_end": "2016-04-15",
+            "amount": {
+              "billed": 145,
+              "paid": 0,
+              "total_coverage": 99.56,
+              "deduction": null,
+              "tax": null,
+              "total_claim_before_taxes": null,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "quantity": {
+              "billed": 0,
+              "paid": 1,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "additional_ids": [],
+            "rendering_provider_ids": [],
+            "allowed_amount": 99.56,
+            "remark_codes": [],
+            "provider_control_number": "123123123",
+            "healthcare_policy": [],
+            "adjustments": [
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "1",
+                "reason_label": "Deductible Amount",
+                "amount": 79.56,
+                "quantity": 0
+              },
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "3",
+                "reason_label": "Co-payment Amount",
+                "amount": 20,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "45",
+                "reason_label": "Charge exceeds fee schedule/maximum allowable or contracted/legislated fee arrangement. (Use only with Group Codes PR or CO depending upon liability)",
+                "amount": 45.44,
+                "quantity": 0
+              }
+            ]
+          },
+          {
+            "procedure_qualifier": "HC<90834",
+            "procedure_code": null,
+            "procedure_modifiers": [],
+            "revenue_code": "",
+            "service_start": "2016-04-15",
+            "service_end": "2016-04-15",
+            "amount": {
+              "billed": 145,
+              "paid": 0,
+              "total_coverage": 99.56,
+              "deduction": null,
+              "tax": null,
+              "total_claim_before_taxes": null,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "quantity": {
+              "billed": 0,
+              "paid": 1,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "additional_ids": [],
+            "rendering_provider_ids": [],
+            "allowed_amount": 99.56,
+            "remark_codes": [],
+            "provider_control_number": "123123123",
+            "healthcare_policy": [],
+            "adjustments": [
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "1",
+                "reason_label": "Deductible Amount",
+                "amount": 79.56,
+                "quantity": 0
+              },
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "3",
+                "reason_label": "Co-payment Amount",
+                "amount": 20,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "45",
+                "reason_label": "Charge exceeds fee schedule/maximum allowable or contracted/legislated fee arrangement. (Use only with Group Codes PR or CO depending upon liability)",
+                "amount": 45.44,
+                "quantity": 0
+              }
+            ]
+          },
+          {
+            "procedure_qualifier": "HC<90834",
+            "procedure_code": null,
+            "procedure_modifiers": [],
+            "revenue_code": "",
+            "service_start": "2016-04-15",
+            "service_end": "2016-04-15",
+            "amount": {
+              "billed": 145,
+              "paid": 33.7,
+              "total_coverage": 99.56,
+              "deduction": null,
+              "tax": null,
+              "total_claim_before_taxes": null,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "quantity": {
+              "billed": 0,
+              "paid": 1,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "additional_ids": [],
+            "rendering_provider_ids": [],
+            "allowed_amount": 99.56,
+            "remark_codes": [],
+            "provider_control_number": "123123123",
+            "healthcare_policy": [],
+            "adjustments": [
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "1",
+                "reason_label": "Deductible Amount",
+                "amount": 40.88,
+                "quantity": 0
+              },
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "3",
+                "reason_label": "Co-payment Amount",
+                "amount": 20,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "144",
+                "reason_label": "Incentive adjustment, e.g. preferred product/service.",
+                "amount": 4.98,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "45",
+                "reason_label": "Charge exceeds fee schedule/maximum allowable or contracted/legislated fee arrangement. (Use only with Group Codes PR or CO depending upon liability)",
+                "amount": 45.44,
+                "quantity": 0
+              }
+            ]
+          }
+        ]
+      },
+      "reference_id": "UTSYSXDXJXY9X"
+    },
+    {
+      "effective_date": "2016-04-15",
+      "payer": {
+        "name": "BCBSM",
+        "id": "ELIG_SNDBX",
+        "address": {
+          "street_line_1": "600 E LAFAYETTE",
+          "street_line_2": null,
+          "city": "DETROIT",
+          "state": "MI",
+          "zip": "482260000"
+        },
+        "contacts": [
+          {
+            "department_code": "CX",
+            "department_label": "Payers Claim Office. Location responsible for paying bills related to medical care received",
+            "name": "EDI HELPDESK",
+            "details": [
+              {
+                "type_code": "TE",
+                "type_label": "Telephone",
+                "value": "8005420945"
+              },
+              {
+                "type_code": "FX",
+                "type_label": "Facsimile",
+                "value": "2484862453"
+              }
+            ]
+          },
+          {
+            "department_code": "BL",
+            "department_label": "Technical Department",
+            "name": "EDI HELPDESK",
+            "details": [
+              {
+                "type_code": "TE",
+                "type_label": "Telephone",
+                "value": "8005420945"
+              },
+              {
+                "type_code": "FX",
+                "type_label": "Facsimile",
+                "value": "2484862453"
+              },
+              {
+                "type_code": "EM",
+                "type_label": "Electronic Mail",
+                "value": "EDI@BCBSM.COM"
+              }
+            ]
+          }
+        ],
+        "crossover_payer": null,
+        "corrected_priority_payer": null
+      },
+      "financials": {
+        "type_code": "I",
+        "type_label": "Remittance Information Only",
+        "total_payment_amount": "1261.03",
+        "credit": true,
+        "debit": false,
+        "payment_method_code": "ACH",
+        "payment_method_label": "Automated Clearing House (ACH)",
+        "payment_format_code": "CCP",
+        "payment_format_label": "Cash Concentration/Disbursement plus Addenda (CCD+) (ACH)",
+        "payment_date": "2016-02-03",
+        "payment_trace_number": "710618145",
+        "sender": {
+          "dfi_id_qualifier": "01",
+          "dfi_id_qualifier_label": "ABA Transit Routing Number Including Check Digits (9 digits)",
+          "dfi_id": "091000019",
+          "account_number": "1382069753",
+          "id": "1382069753",
+          "supplemental_code": ""
+        },
+        "receiver": {
+          "dfi_id_qualifier": "01",
+          "dfi_id_qualifier_label": "ABA Transit Routing Number Including Check Digits (9 digits)",
+          "dfi_id": "072000096",
+          "account_type": "Demand Deposit",
+          "account_number": "1852205283"
+        }
+      },
+      "payee": {
+        "name": "JENNIFER DESCHRYVER INC",
+        "npi": "1932382397",
+        "address": {
+          "street_line_1": null,
+          "street_line_2": null,
+          "city": "BLOOMFLD HLS",
+          "state": "MI",
+          "zip": "483013068"
+        },
+        "additional_ids": [
+          {
+            "type_code": "TJ",
+            "type_label": "Federal Taxpayer's Identification Number",
+            "value": "123123123"
+          }
+        ],
+        "adjustments": [],
+        "delivery_method": null
+      },
+      "patient": {
+        "first_name": "*****MIN",
+        "last_name": "*****LIN",
+        "middle_name": "J",
+        "id": "*******890"
+      },
+      "corrected_patient": {
+        "first_name": null,
+        "last_name": null,
+        "middle_name": null,
+        "id": null
+      },
+      "other_patient": {
+        "first_name": null,
+        "last_name": null,
+        "middle_name": null,
+        "id": null
+      },
+      "service_provider": null,
+      "claim": {
+        "control_number": "26160262372500710",
+        "received_date": "2016-04-15",
+        "expiration_date": null,
+        "filing_indicator_type": "12",
+        "filing_indicator_label": "Preferred Provider Organization (PPO)",
+        "place_of_service": "11",
+        "frequency": "1",
+        "responsibility_sequence": "primary",
+        "status": [
+          "processed"
+        ],
+        "drg_code": null,
+        "drg_quantity": null,
+        "amount": {
+          "billed": 435,
+          "paid": 33.7,
+          "patient_responsibility": 260,
+          "total_coverage": 298.68,
+          "prompt_payment_discount": null,
+          "per_day_limit": null,
+          "patient_paid": null,
+          "revised_interest": null,
+          "negative_ledger_balance": null,
+          "tax": null,
+          "total_claim_before_taxes": null,
+          "federal": {
+            "category_1": null,
+            "category_2": null,
+            "category_3": null,
+            "category_4": null,
+            "category_5": null
+          }
+        },
+        "adjustments": [],
+        "quantity": {
+          "actual": {
+            "covered": null,
+            "co_insured": null,
+            "life_time_reserve": null
+          },
+          "estimated": {
+            "life_time_reserve": null,
+            "non_covered": null
+          },
+          "not_replaced_blood_unit": null,
+          "outlier_days": null,
+          "prescription": null,
+          "visits": null,
+          "federal": {
+            "category_1": null,
+            "category_2": null,
+            "category_3": null,
+            "category_4": null,
+            "category_5": null
+          }
+        },
+        "additional_ids": [],
+        "rendering_provider_ids": [],
+        "moa_codes": [],
+        "allowed_amount": 298.68,
+        "contacts": [],
+        "service_lines": [
+          {
+            "procedure_qualifier": "HC<90834",
+            "procedure_code": null,
+            "procedure_modifiers": [],
+            "revenue_code": "",
+            "service_start": "2016-04-15",
+            "service_end": "2016-04-15",
+            "amount": {
+              "billed": 145,
+              "paid": 0,
+              "total_coverage": 99.56,
+              "deduction": null,
+              "tax": null,
+              "total_claim_before_taxes": null,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "quantity": {
+              "billed": 0,
+              "paid": 1,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "additional_ids": [],
+            "rendering_provider_ids": [],
+            "allowed_amount": 99.56,
+            "remark_codes": [],
+            "provider_control_number": "123123123",
+            "healthcare_policy": [],
+            "adjustments": [
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "1",
+                "reason_label": "Deductible Amount",
+                "amount": 79.56,
+                "quantity": 0
+              },
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "3",
+                "reason_label": "Co-payment Amount",
+                "amount": 20,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "45",
+                "reason_label": "Charge exceeds fee schedule/maximum allowable or contracted/legislated fee arrangement. (Use only with Group Codes PR or CO depending upon liability)",
+                "amount": 45.44,
+                "quantity": 0
+              }
+            ]
+          },
+          {
+            "procedure_qualifier": "HC<90834",
+            "procedure_code": null,
+            "procedure_modifiers": [],
+            "revenue_code": "",
+            "service_start": "2016-04-15",
+            "service_end": "2016-04-15",
+            "amount": {
+              "billed": 145,
+              "paid": 0,
+              "total_coverage": 99.56,
+              "deduction": null,
+              "tax": null,
+              "total_claim_before_taxes": null,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "quantity": {
+              "billed": 0,
+              "paid": 1,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "additional_ids": [],
+            "rendering_provider_ids": [],
+            "allowed_amount": 99.56,
+            "remark_codes": [],
+            "provider_control_number": "123123123",
+            "healthcare_policy": [],
+            "adjustments": [
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "1",
+                "reason_label": "Deductible Amount",
+                "amount": 79.56,
+                "quantity": 0
+              },
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "3",
+                "reason_label": "Co-payment Amount",
+                "amount": 20,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "45",
+                "reason_label": "Charge exceeds fee schedule/maximum allowable or contracted/legislated fee arrangement. (Use only with Group Codes PR or CO depending upon liability)",
+                "amount": 45.44,
+                "quantity": 0
+              }
+            ]
+          },
+          {
+            "procedure_qualifier": "HC<90834",
+            "procedure_code": null,
+            "procedure_modifiers": [],
+            "revenue_code": "",
+            "service_start": "2016-04-15",
+            "service_end": "2016-04-15",
+            "amount": {
+              "billed": 145,
+              "paid": 33.7,
+              "total_coverage": 99.56,
+              "deduction": null,
+              "tax": null,
+              "total_claim_before_taxes": null,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "quantity": {
+              "billed": 0,
+              "paid": 1,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "additional_ids": [],
+            "rendering_provider_ids": [],
+            "allowed_amount": 99.56,
+            "remark_codes": [],
+            "provider_control_number": "123123123",
+            "healthcare_policy": [],
+            "adjustments": [
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "1",
+                "reason_label": "Deductible Amount",
+                "amount": 40.88,
+                "quantity": 0
+              },
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "3",
+                "reason_label": "Co-payment Amount",
+                "amount": 20,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "144",
+                "reason_label": "Incentive adjustment, e.g. preferred product/service.",
+                "amount": 4.98,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "45",
+                "reason_label": "Charge exceeds fee schedule/maximum allowable or contracted/legislated fee arrangement. (Use only with Group Codes PR or CO depending upon liability)",
+                "amount": 45.44,
+                "quantity": 0
+              }
+            ]
+          }
+        ]
+      },
+      "reference_id": "UTSYSXDXJXY9X"
+    },
+    {
+      "effective_date": "2016-04-15",
+      "payer": {
+        "name": "BCBSM",
+        "id": "ELIG_SNDBX",
+        "address": {
+          "street_line_1": "600 E LAFAYETTE",
+          "street_line_2": null,
+          "city": "DETROIT",
+          "state": "MI",
+          "zip": "482260000"
+        },
+        "contacts": [
+          {
+            "department_code": "CX",
+            "department_label": "Payers Claim Office. Location responsible for paying bills related to medical care received",
+            "name": "EDI HELPDESK",
+            "details": [
+              {
+                "type_code": "TE",
+                "type_label": "Telephone",
+                "value": "8005420945"
+              },
+              {
+                "type_code": "FX",
+                "type_label": "Facsimile",
+                "value": "2484862453"
+              }
+            ]
+          },
+          {
+            "department_code": "BL",
+            "department_label": "Technical Department",
+            "name": "EDI HELPDESK",
+            "details": [
+              {
+                "type_code": "TE",
+                "type_label": "Telephone",
+                "value": "8005420945"
+              },
+              {
+                "type_code": "FX",
+                "type_label": "Facsimile",
+                "value": "2484862453"
+              },
+              {
+                "type_code": "EM",
+                "type_label": "Electronic Mail",
+                "value": "EDI@BCBSM.COM"
+              }
+            ]
+          }
+        ],
+        "crossover_payer": null,
+        "corrected_priority_payer": null
+      },
+      "financials": {
+        "type_code": "I",
+        "type_label": "Remittance Information Only",
+        "total_payment_amount": "1261.03",
+        "credit": true,
+        "debit": false,
+        "payment_method_code": "ACH",
+        "payment_method_label": "Automated Clearing House (ACH)",
+        "payment_format_code": "CCP",
+        "payment_format_label": "Cash Concentration/Disbursement plus Addenda (CCD+) (ACH)",
+        "payment_date": "2016-02-03",
+        "payment_trace_number": "710618145",
+        "sender": {
+          "dfi_id_qualifier": "01",
+          "dfi_id_qualifier_label": "ABA Transit Routing Number Including Check Digits (9 digits)",
+          "dfi_id": "091000019",
+          "account_number": "1382069753",
+          "id": "1382069753",
+          "supplemental_code": ""
+        },
+        "receiver": {
+          "dfi_id_qualifier": "01",
+          "dfi_id_qualifier_label": "ABA Transit Routing Number Including Check Digits (9 digits)",
+          "dfi_id": "072000096",
+          "account_type": "Demand Deposit",
+          "account_number": "1852205283"
+        }
+      },
+      "payee": {
+        "name": "JENNIFER DESCHRYVER INC",
+        "npi": "1932382397",
+        "address": {
+          "street_line_1": null,
+          "street_line_2": null,
+          "city": "BLOOMFLD HLS",
+          "state": "MI",
+          "zip": "483013068"
+        },
+        "additional_ids": [
+          {
+            "type_code": "TJ",
+            "type_label": "Federal Taxpayer's Identification Number",
+            "value": "123123123"
+          }
+        ],
+        "adjustments": [],
+        "delivery_method": null
+      },
+      "patient": {
+        "first_name": "*****MIN",
+        "last_name": "*****LIN",
+        "middle_name": "J",
+        "id": "*******890"
+      },
+      "corrected_patient": {
+        "first_name": null,
+        "last_name": null,
+        "middle_name": null,
+        "id": null
+      },
+      "other_patient": {
+        "first_name": null,
+        "last_name": null,
+        "middle_name": null,
+        "id": null
+      },
+      "service_provider": null,
+      "claim": {
+        "control_number": "26160262372500710",
+        "received_date": "2016-04-15",
+        "expiration_date": null,
+        "filing_indicator_type": "12",
+        "filing_indicator_label": "Preferred Provider Organization (PPO)",
+        "place_of_service": "11",
+        "frequency": "1",
+        "responsibility_sequence": "primary",
+        "status": [
+          "processed"
+        ],
+        "drg_code": null,
+        "drg_quantity": null,
+        "amount": {
+          "billed": 435,
+          "paid": 33.7,
+          "patient_responsibility": 260,
+          "total_coverage": 298.68,
+          "prompt_payment_discount": null,
+          "per_day_limit": null,
+          "patient_paid": null,
+          "revised_interest": null,
+          "negative_ledger_balance": null,
+          "tax": null,
+          "total_claim_before_taxes": null,
+          "federal": {
+            "category_1": null,
+            "category_2": null,
+            "category_3": null,
+            "category_4": null,
+            "category_5": null
+          }
+        },
+        "adjustments": [],
+        "quantity": {
+          "actual": {
+            "covered": null,
+            "co_insured": null,
+            "life_time_reserve": null
+          },
+          "estimated": {
+            "life_time_reserve": null,
+            "non_covered": null
+          },
+          "not_replaced_blood_unit": null,
+          "outlier_days": null,
+          "prescription": null,
+          "visits": null,
+          "federal": {
+            "category_1": null,
+            "category_2": null,
+            "category_3": null,
+            "category_4": null,
+            "category_5": null
+          }
+        },
+        "additional_ids": [],
+        "rendering_provider_ids": [],
+        "moa_codes": [],
+        "allowed_amount": 298.68,
+        "contacts": [],
+        "service_lines": [
+          {
+            "procedure_qualifier": "HC<90834",
+            "procedure_code": null,
+            "procedure_modifiers": [],
+            "revenue_code": "",
+            "service_start": "2016-04-15",
+            "service_end": "2016-04-15",
+            "amount": {
+              "billed": 145,
+              "paid": 0,
+              "total_coverage": 99.56,
+              "deduction": null,
+              "tax": null,
+              "total_claim_before_taxes": null,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "quantity": {
+              "billed": 0,
+              "paid": 1,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "additional_ids": [],
+            "rendering_provider_ids": [],
+            "allowed_amount": 99.56,
+            "remark_codes": [],
+            "provider_control_number": "123123123",
+            "healthcare_policy": [],
+            "adjustments": [
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "1",
+                "reason_label": "Deductible Amount",
+                "amount": 79.56,
+                "quantity": 0
+              },
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "3",
+                "reason_label": "Co-payment Amount",
+                "amount": 20,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "45",
+                "reason_label": "Charge exceeds fee schedule/maximum allowable or contracted/legislated fee arrangement. (Use only with Group Codes PR or CO depending upon liability)",
+                "amount": 45.44,
+                "quantity": 0
+              }
+            ]
+          },
+          {
+            "procedure_qualifier": "HC<90834",
+            "procedure_code": null,
+            "procedure_modifiers": [],
+            "revenue_code": "",
+            "service_start": "2016-04-15",
+            "service_end": "2016-04-15",
+            "amount": {
+              "billed": 145,
+              "paid": 0,
+              "total_coverage": 99.56,
+              "deduction": null,
+              "tax": null,
+              "total_claim_before_taxes": null,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "quantity": {
+              "billed": 0,
+              "paid": 1,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "additional_ids": [],
+            "rendering_provider_ids": [],
+            "allowed_amount": 99.56,
+            "remark_codes": [],
+            "provider_control_number": "123123123",
+            "healthcare_policy": [],
+            "adjustments": [
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "1",
+                "reason_label": "Deductible Amount",
+                "amount": 79.56,
+                "quantity": 0
+              },
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "3",
+                "reason_label": "Co-payment Amount",
+                "amount": 20,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "45",
+                "reason_label": "Charge exceeds fee schedule/maximum allowable or contracted/legislated fee arrangement. (Use only with Group Codes PR or CO depending upon liability)",
+                "amount": 45.44,
+                "quantity": 0
+              }
+            ]
+          },
+          {
+            "procedure_qualifier": "HC<90834",
+            "procedure_code": null,
+            "procedure_modifiers": [],
+            "revenue_code": "",
+            "service_start": "2016-04-15",
+            "service_end": "2016-04-15",
+            "amount": {
+              "billed": 145,
+              "paid": 33.7,
+              "total_coverage": 99.56,
+              "deduction": null,
+              "tax": null,
+              "total_claim_before_taxes": null,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "quantity": {
+              "billed": 0,
+              "paid": 1,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "additional_ids": [],
+            "rendering_provider_ids": [],
+            "allowed_amount": 99.56,
+            "remark_codes": [],
+            "provider_control_number": "123123123",
+            "healthcare_policy": [],
+            "adjustments": [
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "1",
+                "reason_label": "Deductible Amount",
+                "amount": 40.88,
+                "quantity": 0
+              },
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "3",
+                "reason_label": "Co-payment Amount",
+                "amount": 20,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "144",
+                "reason_label": "Incentive adjustment, e.g. preferred product/service.",
+                "amount": 4.98,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "45",
+                "reason_label": "Charge exceeds fee schedule/maximum allowable or contracted/legislated fee arrangement. (Use only with Group Codes PR or CO depending upon liability)",
+                "amount": 45.44,
+                "quantity": 0
+              }
+            ]
+          }
+        ]
+      },
+      "reference_id": "UTSYSXDXJXY9X"
+    },
+    {
+      "effective_date": "2016-04-15",
+      "payer": {
+        "name": "BCBSM",
+        "id": "ELIG_SNDBX",
+        "address": {
+          "street_line_1": "600 E LAFAYETTE",
+          "street_line_2": null,
+          "city": "DETROIT",
+          "state": "MI",
+          "zip": "482260000"
+        },
+        "contacts": [
+          {
+            "department_code": "CX",
+            "department_label": "Payers Claim Office. Location responsible for paying bills related to medical care received",
+            "name": "EDI HELPDESK",
+            "details": [
+              {
+                "type_code": "TE",
+                "type_label": "Telephone",
+                "value": "8005420945"
+              },
+              {
+                "type_code": "FX",
+                "type_label": "Facsimile",
+                "value": "2484862453"
+              }
+            ]
+          },
+          {
+            "department_code": "BL",
+            "department_label": "Technical Department",
+            "name": "EDI HELPDESK",
+            "details": [
+              {
+                "type_code": "TE",
+                "type_label": "Telephone",
+                "value": "8005420945"
+              },
+              {
+                "type_code": "FX",
+                "type_label": "Facsimile",
+                "value": "2484862453"
+              },
+              {
+                "type_code": "EM",
+                "type_label": "Electronic Mail",
+                "value": "EDI@BCBSM.COM"
+              }
+            ]
+          }
+        ],
+        "crossover_payer": null,
+        "corrected_priority_payer": null
+      },
+      "financials": {
+        "type_code": "I",
+        "type_label": "Remittance Information Only",
+        "total_payment_amount": "1261.03",
+        "credit": true,
+        "debit": false,
+        "payment_method_code": "ACH",
+        "payment_method_label": "Automated Clearing House (ACH)",
+        "payment_format_code": "CCP",
+        "payment_format_label": "Cash Concentration/Disbursement plus Addenda (CCD+) (ACH)",
+        "payment_date": "2016-02-03",
+        "payment_trace_number": "710618145",
+        "sender": {
+          "dfi_id_qualifier": "01",
+          "dfi_id_qualifier_label": "ABA Transit Routing Number Including Check Digits (9 digits)",
+          "dfi_id": "091000019",
+          "account_number": "1382069753",
+          "id": "1382069753",
+          "supplemental_code": ""
+        },
+        "receiver": {
+          "dfi_id_qualifier": "01",
+          "dfi_id_qualifier_label": "ABA Transit Routing Number Including Check Digits (9 digits)",
+          "dfi_id": "072000096",
+          "account_type": "Demand Deposit",
+          "account_number": "1852205283"
+        }
+      },
+      "payee": {
+        "name": "JENNIFER DESCHRYVER INC",
+        "npi": "1932382397",
+        "address": {
+          "street_line_1": null,
+          "street_line_2": null,
+          "city": "BLOOMFLD HLS",
+          "state": "MI",
+          "zip": "483013068"
+        },
+        "additional_ids": [
+          {
+            "type_code": "TJ",
+            "type_label": "Federal Taxpayer's Identification Number",
+            "value": "123123123"
+          }
+        ],
+        "adjustments": [],
+        "delivery_method": null
+      },
+      "patient": {
+        "first_name": "*****MIN",
+        "last_name": "*****LIN",
+        "middle_name": "J",
+        "id": "*******890"
+      },
+      "corrected_patient": {
+        "first_name": null,
+        "last_name": null,
+        "middle_name": null,
+        "id": null
+      },
+      "other_patient": {
+        "first_name": null,
+        "last_name": null,
+        "middle_name": null,
+        "id": null
+      },
+      "service_provider": null,
+      "claim": {
+        "control_number": "26160262372500710",
+        "received_date": "2016-04-15",
+        "expiration_date": null,
+        "filing_indicator_type": "12",
+        "filing_indicator_label": "Preferred Provider Organization (PPO)",
+        "place_of_service": "11",
+        "frequency": "1",
+        "responsibility_sequence": "primary",
+        "status": [
+          "processed"
+        ],
+        "drg_code": null,
+        "drg_quantity": null,
+        "amount": {
+          "billed": 435,
+          "paid": 33.7,
+          "patient_responsibility": 260,
+          "total_coverage": 298.68,
+          "prompt_payment_discount": null,
+          "per_day_limit": null,
+          "patient_paid": null,
+          "revised_interest": null,
+          "negative_ledger_balance": null,
+          "tax": null,
+          "total_claim_before_taxes": null,
+          "federal": {
+            "category_1": null,
+            "category_2": null,
+            "category_3": null,
+            "category_4": null,
+            "category_5": null
+          }
+        },
+        "adjustments": [],
+        "quantity": {
+          "actual": {
+            "covered": null,
+            "co_insured": null,
+            "life_time_reserve": null
+          },
+          "estimated": {
+            "life_time_reserve": null,
+            "non_covered": null
+          },
+          "not_replaced_blood_unit": null,
+          "outlier_days": null,
+          "prescription": null,
+          "visits": null,
+          "federal": {
+            "category_1": null,
+            "category_2": null,
+            "category_3": null,
+            "category_4": null,
+            "category_5": null
+          }
+        },
+        "additional_ids": [],
+        "rendering_provider_ids": [],
+        "moa_codes": [],
+        "allowed_amount": 298.68,
+        "contacts": [],
+        "service_lines": [
+          {
+            "procedure_qualifier": "HC<90834",
+            "procedure_code": null,
+            "procedure_modifiers": [],
+            "revenue_code": "",
+            "service_start": "2016-04-15",
+            "service_end": "2016-04-15",
+            "amount": {
+              "billed": 145,
+              "paid": 0,
+              "total_coverage": 99.56,
+              "deduction": null,
+              "tax": null,
+              "total_claim_before_taxes": null,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "quantity": {
+              "billed": 0,
+              "paid": 1,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "additional_ids": [],
+            "rendering_provider_ids": [],
+            "allowed_amount": 99.56,
+            "remark_codes": [],
+            "provider_control_number": "123123123",
+            "healthcare_policy": [],
+            "adjustments": [
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "1",
+                "reason_label": "Deductible Amount",
+                "amount": 79.56,
+                "quantity": 0
+              },
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "3",
+                "reason_label": "Co-payment Amount",
+                "amount": 20,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "45",
+                "reason_label": "Charge exceeds fee schedule/maximum allowable or contracted/legislated fee arrangement. (Use only with Group Codes PR or CO depending upon liability)",
+                "amount": 45.44,
+                "quantity": 0
+              }
+            ]
+          },
+          {
+            "procedure_qualifier": "HC<90834",
+            "procedure_code": null,
+            "procedure_modifiers": [],
+            "revenue_code": "",
+            "service_start": "2016-04-15",
+            "service_end": "2016-04-15",
+            "amount": {
+              "billed": 145,
+              "paid": 0,
+              "total_coverage": 99.56,
+              "deduction": null,
+              "tax": null,
+              "total_claim_before_taxes": null,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "quantity": {
+              "billed": 0,
+              "paid": 1,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "additional_ids": [],
+            "rendering_provider_ids": [],
+            "allowed_amount": 99.56,
+            "remark_codes": [],
+            "provider_control_number": "123123123",
+            "healthcare_policy": [],
+            "adjustments": [
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "1",
+                "reason_label": "Deductible Amount",
+                "amount": 79.56,
+                "quantity": 0
+              },
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "3",
+                "reason_label": "Co-payment Amount",
+                "amount": 20,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "45",
+                "reason_label": "Charge exceeds fee schedule/maximum allowable or contracted/legislated fee arrangement. (Use only with Group Codes PR or CO depending upon liability)",
+                "amount": 45.44,
+                "quantity": 0
+              }
+            ]
+          },
+          {
+            "procedure_qualifier": "HC<90834",
+            "procedure_code": null,
+            "procedure_modifiers": [],
+            "revenue_code": "",
+            "service_start": "2016-04-15",
+            "service_end": "2016-04-15",
+            "amount": {
+              "billed": 145,
+              "paid": 33.7,
+              "total_coverage": 99.56,
+              "deduction": null,
+              "tax": null,
+              "total_claim_before_taxes": null,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "quantity": {
+              "billed": 0,
+              "paid": 1,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "additional_ids": [],
+            "rendering_provider_ids": [],
+            "allowed_amount": 99.56,
+            "remark_codes": [],
+            "provider_control_number": "123123123",
+            "healthcare_policy": [],
+            "adjustments": [
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "1",
+                "reason_label": "Deductible Amount",
+                "amount": 40.88,
+                "quantity": 0
+              },
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "3",
+                "reason_label": "Co-payment Amount",
+                "amount": 20,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "144",
+                "reason_label": "Incentive adjustment, e.g. preferred product/service.",
+                "amount": 4.98,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "45",
+                "reason_label": "Charge exceeds fee schedule/maximum allowable or contracted/legislated fee arrangement. (Use only with Group Codes PR or CO depending upon liability)",
+                "amount": 45.44,
+                "quantity": 0
+              }
+            ]
+          }
+        ]
+      },
+      "reference_id": "UTSYSRZ0ZCGG5"
+    },
+    {
+      "effective_date": "2016-04-15",
+      "payer": {
+        "name": "BCBSM",
+        "id": "ELIG_SNDBX",
+        "address": {
+          "street_line_1": "600 E LAFAYETTE",
+          "street_line_2": null,
+          "city": "DETROIT",
+          "state": "MI",
+          "zip": "482260000"
+        },
+        "contacts": [
+          {
+            "department_code": "CX",
+            "department_label": "Payers Claim Office. Location responsible for paying bills related to medical care received",
+            "name": "EDI HELPDESK",
+            "details": [
+              {
+                "type_code": "TE",
+                "type_label": "Telephone",
+                "value": "8005420945"
+              },
+              {
+                "type_code": "FX",
+                "type_label": "Facsimile",
+                "value": "2484862453"
+              }
+            ]
+          },
+          {
+            "department_code": "BL",
+            "department_label": "Technical Department",
+            "name": "EDI HELPDESK",
+            "details": [
+              {
+                "type_code": "TE",
+                "type_label": "Telephone",
+                "value": "8005420945"
+              },
+              {
+                "type_code": "FX",
+                "type_label": "Facsimile",
+                "value": "2484862453"
+              },
+              {
+                "type_code": "EM",
+                "type_label": "Electronic Mail",
+                "value": "EDI@BCBSM.COM"
+              }
+            ]
+          }
+        ],
+        "crossover_payer": null,
+        "corrected_priority_payer": null
+      },
+      "financials": {
+        "type_code": "I",
+        "type_label": "Remittance Information Only",
+        "total_payment_amount": "1261.03",
+        "credit": true,
+        "debit": false,
+        "payment_method_code": "ACH",
+        "payment_method_label": "Automated Clearing House (ACH)",
+        "payment_format_code": "CCP",
+        "payment_format_label": "Cash Concentration/Disbursement plus Addenda (CCD+) (ACH)",
+        "payment_date": "2016-02-03",
+        "payment_trace_number": "710618145",
+        "sender": {
+          "dfi_id_qualifier": "01",
+          "dfi_id_qualifier_label": "ABA Transit Routing Number Including Check Digits (9 digits)",
+          "dfi_id": "091000019",
+          "account_number": "1382069753",
+          "id": "1382069753",
+          "supplemental_code": ""
+        },
+        "receiver": {
+          "dfi_id_qualifier": "01",
+          "dfi_id_qualifier_label": "ABA Transit Routing Number Including Check Digits (9 digits)",
+          "dfi_id": "072000096",
+          "account_type": "Demand Deposit",
+          "account_number": "1852205283"
+        }
+      },
+      "payee": {
+        "name": "JENNIFER DESCHRYVER INC",
+        "npi": "1932382397",
+        "address": {
+          "street_line_1": null,
+          "street_line_2": null,
+          "city": "BLOOMFLD HLS",
+          "state": "MI",
+          "zip": "483013068"
+        },
+        "additional_ids": [
+          {
+            "type_code": "TJ",
+            "type_label": "Federal Taxpayer's Identification Number",
+            "value": "123123123"
+          }
+        ],
+        "adjustments": [],
+        "delivery_method": null
+      },
+      "patient": {
+        "first_name": "*****MIN",
+        "last_name": "*****LIN",
+        "middle_name": "J",
+        "id": "*******890"
+      },
+      "corrected_patient": {
+        "first_name": null,
+        "last_name": null,
+        "middle_name": null,
+        "id": null
+      },
+      "other_patient": {
+        "first_name": null,
+        "last_name": null,
+        "middle_name": null,
+        "id": null
+      },
+      "service_provider": null,
+      "claim": {
+        "control_number": "26160262372500710",
+        "received_date": "2016-04-15",
+        "expiration_date": null,
+        "filing_indicator_type": "12",
+        "filing_indicator_label": "Preferred Provider Organization (PPO)",
+        "place_of_service": "11",
+        "frequency": "1",
+        "responsibility_sequence": "primary",
+        "status": [
+          "processed"
+        ],
+        "drg_code": null,
+        "drg_quantity": null,
+        "amount": {
+          "billed": 435,
+          "paid": 33.7,
+          "patient_responsibility": 260,
+          "total_coverage": 298.68,
+          "prompt_payment_discount": null,
+          "per_day_limit": null,
+          "patient_paid": null,
+          "revised_interest": null,
+          "negative_ledger_balance": null,
+          "tax": null,
+          "total_claim_before_taxes": null,
+          "federal": {
+            "category_1": null,
+            "category_2": null,
+            "category_3": null,
+            "category_4": null,
+            "category_5": null
+          }
+        },
+        "adjustments": [],
+        "quantity": {
+          "actual": {
+            "covered": null,
+            "co_insured": null,
+            "life_time_reserve": null
+          },
+          "estimated": {
+            "life_time_reserve": null,
+            "non_covered": null
+          },
+          "not_replaced_blood_unit": null,
+          "outlier_days": null,
+          "prescription": null,
+          "visits": null,
+          "federal": {
+            "category_1": null,
+            "category_2": null,
+            "category_3": null,
+            "category_4": null,
+            "category_5": null
+          }
+        },
+        "additional_ids": [],
+        "rendering_provider_ids": [],
+        "moa_codes": [],
+        "allowed_amount": 298.68,
+        "contacts": [],
+        "service_lines": [
+          {
+            "procedure_qualifier": "HC<90834",
+            "procedure_code": null,
+            "procedure_modifiers": [],
+            "revenue_code": "",
+            "service_start": "2016-04-15",
+            "service_end": "2016-04-15",
+            "amount": {
+              "billed": 145,
+              "paid": 0,
+              "total_coverage": 99.56,
+              "deduction": null,
+              "tax": null,
+              "total_claim_before_taxes": null,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "quantity": {
+              "billed": 0,
+              "paid": 1,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "additional_ids": [],
+            "rendering_provider_ids": [],
+            "allowed_amount": 99.56,
+            "remark_codes": [],
+            "provider_control_number": "123123123",
+            "healthcare_policy": [],
+            "adjustments": [
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "1",
+                "reason_label": "Deductible Amount",
+                "amount": 79.56,
+                "quantity": 0
+              },
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "3",
+                "reason_label": "Co-payment Amount",
+                "amount": 20,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "45",
+                "reason_label": "Charge exceeds fee schedule/maximum allowable or contracted/legislated fee arrangement. (Use only with Group Codes PR or CO depending upon liability)",
+                "amount": 45.44,
+                "quantity": 0
+              }
+            ]
+          },
+          {
+            "procedure_qualifier": "HC<90834",
+            "procedure_code": null,
+            "procedure_modifiers": [],
+            "revenue_code": "",
+            "service_start": "2016-04-15",
+            "service_end": "2016-04-15",
+            "amount": {
+              "billed": 145,
+              "paid": 0,
+              "total_coverage": 99.56,
+              "deduction": null,
+              "tax": null,
+              "total_claim_before_taxes": null,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "quantity": {
+              "billed": 0,
+              "paid": 1,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "additional_ids": [],
+            "rendering_provider_ids": [],
+            "allowed_amount": 99.56,
+            "remark_codes": [],
+            "provider_control_number": "123123123",
+            "healthcare_policy": [],
+            "adjustments": [
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "1",
+                "reason_label": "Deductible Amount",
+                "amount": 79.56,
+                "quantity": 0
+              },
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "3",
+                "reason_label": "Co-payment Amount",
+                "amount": 20,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "45",
+                "reason_label": "Charge exceeds fee schedule/maximum allowable or contracted/legislated fee arrangement. (Use only with Group Codes PR or CO depending upon liability)",
+                "amount": 45.44,
+                "quantity": 0
+              }
+            ]
+          },
+          {
+            "procedure_qualifier": "HC<90834",
+            "procedure_code": null,
+            "procedure_modifiers": [],
+            "revenue_code": "",
+            "service_start": "2016-04-15",
+            "service_end": "2016-04-15",
+            "amount": {
+              "billed": 145,
+              "paid": 33.7,
+              "total_coverage": 99.56,
+              "deduction": null,
+              "tax": null,
+              "total_claim_before_taxes": null,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "quantity": {
+              "billed": 0,
+              "paid": 1,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "additional_ids": [],
+            "rendering_provider_ids": [],
+            "allowed_amount": 99.56,
+            "remark_codes": [],
+            "provider_control_number": "123123123",
+            "healthcare_policy": [],
+            "adjustments": [
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "1",
+                "reason_label": "Deductible Amount",
+                "amount": 40.88,
+                "quantity": 0
+              },
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "3",
+                "reason_label": "Co-payment Amount",
+                "amount": 20,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "144",
+                "reason_label": "Incentive adjustment, e.g. preferred product/service.",
+                "amount": 4.98,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "45",
+                "reason_label": "Charge exceeds fee schedule/maximum allowable or contracted/legislated fee arrangement. (Use only with Group Codes PR or CO depending upon liability)",
+                "amount": 45.44,
+                "quantity": 0
+              }
+            ]
+          }
+        ]
+      },
+      "reference_id": "UTSYSRZ0ZCGG5"
+    },
+    {
+      "effective_date": "2016-04-15",
+      "payer": {
+        "name": "BCBSM",
+        "id": "ELIG_SNDBX",
+        "address": {
+          "street_line_1": "600 E LAFAYETTE",
+          "street_line_2": null,
+          "city": "DETROIT",
+          "state": "MI",
+          "zip": "482260000"
+        },
+        "contacts": [
+          {
+            "department_code": "CX",
+            "department_label": "Payers Claim Office. Location responsible for paying bills related to medical care received",
+            "name": "EDI HELPDESK",
+            "details": [
+              {
+                "type_code": "TE",
+                "type_label": "Telephone",
+                "value": "8005420945"
+              },
+              {
+                "type_code": "FX",
+                "type_label": "Facsimile",
+                "value": "2484862453"
+              }
+            ]
+          },
+          {
+            "department_code": "BL",
+            "department_label": "Technical Department",
+            "name": "EDI HELPDESK",
+            "details": [
+              {
+                "type_code": "TE",
+                "type_label": "Telephone",
+                "value": "8005420945"
+              },
+              {
+                "type_code": "FX",
+                "type_label": "Facsimile",
+                "value": "2484862453"
+              },
+              {
+                "type_code": "EM",
+                "type_label": "Electronic Mail",
+                "value": "EDI@BCBSM.COM"
+              }
+            ]
+          }
+        ],
+        "crossover_payer": null,
+        "corrected_priority_payer": null
+      },
+      "financials": {
+        "type_code": "I",
+        "type_label": "Remittance Information Only",
+        "total_payment_amount": "1261.03",
+        "credit": true,
+        "debit": false,
+        "payment_method_code": "ACH",
+        "payment_method_label": "Automated Clearing House (ACH)",
+        "payment_format_code": "CCP",
+        "payment_format_label": "Cash Concentration/Disbursement plus Addenda (CCD+) (ACH)",
+        "payment_date": "2016-02-03",
+        "payment_trace_number": "710618145",
+        "sender": {
+          "dfi_id_qualifier": "01",
+          "dfi_id_qualifier_label": "ABA Transit Routing Number Including Check Digits (9 digits)",
+          "dfi_id": "091000019",
+          "account_number": "1382069753",
+          "id": "1382069753",
+          "supplemental_code": ""
+        },
+        "receiver": {
+          "dfi_id_qualifier": "01",
+          "dfi_id_qualifier_label": "ABA Transit Routing Number Including Check Digits (9 digits)",
+          "dfi_id": "072000096",
+          "account_type": "Demand Deposit",
+          "account_number": "1852205283"
+        }
+      },
+      "payee": {
+        "name": "JENNIFER DESCHRYVER INC",
+        "npi": "1932382397",
+        "address": {
+          "street_line_1": null,
+          "street_line_2": null,
+          "city": "BLOOMFLD HLS",
+          "state": "MI",
+          "zip": "483013068"
+        },
+        "additional_ids": [
+          {
+            "type_code": "TJ",
+            "type_label": "Federal Taxpayer's Identification Number",
+            "value": "123123123"
+          }
+        ],
+        "adjustments": [],
+        "delivery_method": null
+      },
+      "patient": {
+        "first_name": "*****MIN",
+        "last_name": "*****LIN",
+        "middle_name": "J",
+        "id": "*******890"
+      },
+      "corrected_patient": {
+        "first_name": null,
+        "last_name": null,
+        "middle_name": null,
+        "id": null
+      },
+      "other_patient": {
+        "first_name": null,
+        "last_name": null,
+        "middle_name": null,
+        "id": null
+      },
+      "service_provider": null,
+      "claim": {
+        "control_number": "26160262372500710",
+        "received_date": "2016-04-15",
+        "expiration_date": null,
+        "filing_indicator_type": "12",
+        "filing_indicator_label": "Preferred Provider Organization (PPO)",
+        "place_of_service": "11",
+        "frequency": "1",
+        "responsibility_sequence": "primary",
+        "status": [
+          "processed"
+        ],
+        "drg_code": null,
+        "drg_quantity": null,
+        "amount": {
+          "billed": 435,
+          "paid": 33.7,
+          "patient_responsibility": 260,
+          "total_coverage": 298.68,
+          "prompt_payment_discount": null,
+          "per_day_limit": null,
+          "patient_paid": null,
+          "revised_interest": null,
+          "negative_ledger_balance": null,
+          "tax": null,
+          "total_claim_before_taxes": null,
+          "federal": {
+            "category_1": null,
+            "category_2": null,
+            "category_3": null,
+            "category_4": null,
+            "category_5": null
+          }
+        },
+        "adjustments": [],
+        "quantity": {
+          "actual": {
+            "covered": null,
+            "co_insured": null,
+            "life_time_reserve": null
+          },
+          "estimated": {
+            "life_time_reserve": null,
+            "non_covered": null
+          },
+          "not_replaced_blood_unit": null,
+          "outlier_days": null,
+          "prescription": null,
+          "visits": null,
+          "federal": {
+            "category_1": null,
+            "category_2": null,
+            "category_3": null,
+            "category_4": null,
+            "category_5": null
+          }
+        },
+        "additional_ids": [],
+        "rendering_provider_ids": [],
+        "moa_codes": [],
+        "allowed_amount": 298.68,
+        "contacts": [],
+        "service_lines": [
+          {
+            "procedure_qualifier": "HC<90834",
+            "procedure_code": null,
+            "procedure_modifiers": [],
+            "revenue_code": "",
+            "service_start": "2016-04-15",
+            "service_end": "2016-04-15",
+            "amount": {
+              "billed": 145,
+              "paid": 0,
+              "total_coverage": 99.56,
+              "deduction": null,
+              "tax": null,
+              "total_claim_before_taxes": null,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "quantity": {
+              "billed": 0,
+              "paid": 1,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "additional_ids": [],
+            "rendering_provider_ids": [],
+            "allowed_amount": 99.56,
+            "remark_codes": [],
+            "provider_control_number": "123123123",
+            "healthcare_policy": [],
+            "adjustments": [
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "1",
+                "reason_label": "Deductible Amount",
+                "amount": 79.56,
+                "quantity": 0
+              },
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "3",
+                "reason_label": "Co-payment Amount",
+                "amount": 20,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "45",
+                "reason_label": "Charge exceeds fee schedule/maximum allowable or contracted/legislated fee arrangement. (Use only with Group Codes PR or CO depending upon liability)",
+                "amount": 45.44,
+                "quantity": 0
+              }
+            ]
+          },
+          {
+            "procedure_qualifier": "HC<90834",
+            "procedure_code": null,
+            "procedure_modifiers": [],
+            "revenue_code": "",
+            "service_start": "2016-04-15",
+            "service_end": "2016-04-15",
+            "amount": {
+              "billed": 145,
+              "paid": 0,
+              "total_coverage": 99.56,
+              "deduction": null,
+              "tax": null,
+              "total_claim_before_taxes": null,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "quantity": {
+              "billed": 0,
+              "paid": 1,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "additional_ids": [],
+            "rendering_provider_ids": [],
+            "allowed_amount": 99.56,
+            "remark_codes": [],
+            "provider_control_number": "123123123",
+            "healthcare_policy": [],
+            "adjustments": [
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "1",
+                "reason_label": "Deductible Amount",
+                "amount": 79.56,
+                "quantity": 0
+              },
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "3",
+                "reason_label": "Co-payment Amount",
+                "amount": 20,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "45",
+                "reason_label": "Charge exceeds fee schedule/maximum allowable or contracted/legislated fee arrangement. (Use only with Group Codes PR or CO depending upon liability)",
+                "amount": 45.44,
+                "quantity": 0
+              }
+            ]
+          },
+          {
+            "procedure_qualifier": "HC<90834",
+            "procedure_code": null,
+            "procedure_modifiers": [],
+            "revenue_code": "",
+            "service_start": "2016-04-15",
+            "service_end": "2016-04-15",
+            "amount": {
+              "billed": 145,
+              "paid": 33.7,
+              "total_coverage": 99.56,
+              "deduction": null,
+              "tax": null,
+              "total_claim_before_taxes": null,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "quantity": {
+              "billed": 0,
+              "paid": 1,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "additional_ids": [],
+            "rendering_provider_ids": [],
+            "allowed_amount": 99.56,
+            "remark_codes": [],
+            "provider_control_number": "123123123",
+            "healthcare_policy": [],
+            "adjustments": [
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "1",
+                "reason_label": "Deductible Amount",
+                "amount": 40.88,
+                "quantity": 0
+              },
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "3",
+                "reason_label": "Co-payment Amount",
+                "amount": 20,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "144",
+                "reason_label": "Incentive adjustment, e.g. preferred product/service.",
+                "amount": 4.98,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "45",
+                "reason_label": "Charge exceeds fee schedule/maximum allowable or contracted/legislated fee arrangement. (Use only with Group Codes PR or CO depending upon liability)",
+                "amount": 45.44,
+                "quantity": 0
+              }
+            ]
+          }
+        ]
+      },
+      "reference_id": "8KA1O09BR4QP7G"
+    },
+    {
+      "effective_date": "2016-04-15",
+      "payer": {
+        "name": "BCBSM",
+        "id": "ELIG_SNDBX",
+        "address": {
+          "street_line_1": "600 E LAFAYETTE",
+          "street_line_2": null,
+          "city": "DETROIT",
+          "state": "MI",
+          "zip": "482260000"
+        },
+        "contacts": [
+          {
+            "department_code": "CX",
+            "department_label": "Payers Claim Office. Location responsible for paying bills related to medical care received",
+            "name": "EDI HELPDESK",
+            "details": [
+              {
+                "type_code": "TE",
+                "type_label": "Telephone",
+                "value": "8005420945"
+              },
+              {
+                "type_code": "FX",
+                "type_label": "Facsimile",
+                "value": "2484862453"
+              }
+            ]
+          },
+          {
+            "department_code": "BL",
+            "department_label": "Technical Department",
+            "name": "EDI HELPDESK",
+            "details": [
+              {
+                "type_code": "TE",
+                "type_label": "Telephone",
+                "value": "8005420945"
+              },
+              {
+                "type_code": "FX",
+                "type_label": "Facsimile",
+                "value": "2484862453"
+              },
+              {
+                "type_code": "EM",
+                "type_label": "Electronic Mail",
+                "value": "EDI@BCBSM.COM"
+              }
+            ]
+          }
+        ],
+        "crossover_payer": null,
+        "corrected_priority_payer": null
+      },
+      "financials": {
+        "type_code": "I",
+        "type_label": "Remittance Information Only",
+        "total_payment_amount": "1261.03",
+        "credit": true,
+        "debit": false,
+        "payment_method_code": "ACH",
+        "payment_method_label": "Automated Clearing House (ACH)",
+        "payment_format_code": "CCP",
+        "payment_format_label": "Cash Concentration/Disbursement plus Addenda (CCD+) (ACH)",
+        "payment_date": "2016-02-03",
+        "payment_trace_number": "710618145",
+        "sender": {
+          "dfi_id_qualifier": "01",
+          "dfi_id_qualifier_label": "ABA Transit Routing Number Including Check Digits (9 digits)",
+          "dfi_id": "091000019",
+          "account_number": "1382069753",
+          "id": "1382069753",
+          "supplemental_code": ""
+        },
+        "receiver": {
+          "dfi_id_qualifier": "01",
+          "dfi_id_qualifier_label": "ABA Transit Routing Number Including Check Digits (9 digits)",
+          "dfi_id": "072000096",
+          "account_type": "Demand Deposit",
+          "account_number": "1852205283"
+        }
+      },
+      "payee": {
+        "name": "JENNIFER DESCHRYVER INC",
+        "npi": "1932382397",
+        "address": {
+          "street_line_1": null,
+          "street_line_2": null,
+          "city": "BLOOMFLD HLS",
+          "state": "MI",
+          "zip": "483013068"
+        },
+        "additional_ids": [
+          {
+            "type_code": "TJ",
+            "type_label": "Federal Taxpayer's Identification Number",
+            "value": "123123123"
+          }
+        ],
+        "adjustments": [],
+        "delivery_method": null
+      },
+      "patient": {
+        "first_name": "*****MIN",
+        "last_name": "*****LIN",
+        "middle_name": "J",
+        "id": "*******890"
+      },
+      "corrected_patient": {
+        "first_name": null,
+        "last_name": null,
+        "middle_name": null,
+        "id": null
+      },
+      "other_patient": {
+        "first_name": null,
+        "last_name": null,
+        "middle_name": null,
+        "id": null
+      },
+      "service_provider": null,
+      "claim": {
+        "control_number": "26160262372500710",
+        "received_date": "2016-04-15",
+        "expiration_date": null,
+        "filing_indicator_type": "12",
+        "filing_indicator_label": "Preferred Provider Organization (PPO)",
+        "place_of_service": "11",
+        "frequency": "1",
+        "responsibility_sequence": "primary",
+        "status": [
+          "processed"
+        ],
+        "drg_code": null,
+        "drg_quantity": null,
+        "amount": {
+          "billed": 435,
+          "paid": 33.7,
+          "patient_responsibility": 260,
+          "total_coverage": 298.68,
+          "prompt_payment_discount": null,
+          "per_day_limit": null,
+          "patient_paid": null,
+          "revised_interest": null,
+          "negative_ledger_balance": null,
+          "tax": null,
+          "total_claim_before_taxes": null,
+          "federal": {
+            "category_1": null,
+            "category_2": null,
+            "category_3": null,
+            "category_4": null,
+            "category_5": null
+          }
+        },
+        "adjustments": [],
+        "quantity": {
+          "actual": {
+            "covered": null,
+            "co_insured": null,
+            "life_time_reserve": null
+          },
+          "estimated": {
+            "life_time_reserve": null,
+            "non_covered": null
+          },
+          "not_replaced_blood_unit": null,
+          "outlier_days": null,
+          "prescription": null,
+          "visits": null,
+          "federal": {
+            "category_1": null,
+            "category_2": null,
+            "category_3": null,
+            "category_4": null,
+            "category_5": null
+          }
+        },
+        "additional_ids": [],
+        "rendering_provider_ids": [],
+        "moa_codes": [],
+        "allowed_amount": 298.68,
+        "contacts": [],
+        "service_lines": [
+          {
+            "procedure_qualifier": "HC<90834",
+            "procedure_code": null,
+            "procedure_modifiers": [],
+            "revenue_code": "",
+            "service_start": "2016-04-15",
+            "service_end": "2016-04-15",
+            "amount": {
+              "billed": 145,
+              "paid": 0,
+              "total_coverage": 99.56,
+              "deduction": null,
+              "tax": null,
+              "total_claim_before_taxes": null,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "quantity": {
+              "billed": 0,
+              "paid": 1,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "additional_ids": [],
+            "rendering_provider_ids": [],
+            "allowed_amount": 99.56,
+            "remark_codes": [],
+            "provider_control_number": "123123123",
+            "healthcare_policy": [],
+            "adjustments": [
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "1",
+                "reason_label": "Deductible Amount",
+                "amount": 79.56,
+                "quantity": 0
+              },
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "3",
+                "reason_label": "Co-payment Amount",
+                "amount": 20,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "45",
+                "reason_label": "Charge exceeds fee schedule/maximum allowable or contracted/legislated fee arrangement. (Use only with Group Codes PR or CO depending upon liability)",
+                "amount": 45.44,
+                "quantity": 0
+              }
+            ]
+          },
+          {
+            "procedure_qualifier": "HC<90834",
+            "procedure_code": null,
+            "procedure_modifiers": [],
+            "revenue_code": "",
+            "service_start": "2016-04-15",
+            "service_end": "2016-04-15",
+            "amount": {
+              "billed": 145,
+              "paid": 0,
+              "total_coverage": 99.56,
+              "deduction": null,
+              "tax": null,
+              "total_claim_before_taxes": null,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "quantity": {
+              "billed": 0,
+              "paid": 1,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "additional_ids": [],
+            "rendering_provider_ids": [],
+            "allowed_amount": 99.56,
+            "remark_codes": [],
+            "provider_control_number": "123123123",
+            "healthcare_policy": [],
+            "adjustments": [
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "1",
+                "reason_label": "Deductible Amount",
+                "amount": 79.56,
+                "quantity": 0
+              },
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "3",
+                "reason_label": "Co-payment Amount",
+                "amount": 20,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "45",
+                "reason_label": "Charge exceeds fee schedule/maximum allowable or contracted/legislated fee arrangement. (Use only with Group Codes PR or CO depending upon liability)",
+                "amount": 45.44,
+                "quantity": 0
+              }
+            ]
+          },
+          {
+            "procedure_qualifier": "HC<90834",
+            "procedure_code": null,
+            "procedure_modifiers": [],
+            "revenue_code": "",
+            "service_start": "2016-04-15",
+            "service_end": "2016-04-15",
+            "amount": {
+              "billed": 145,
+              "paid": 33.7,
+              "total_coverage": 99.56,
+              "deduction": null,
+              "tax": null,
+              "total_claim_before_taxes": null,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "quantity": {
+              "billed": 0,
+              "paid": 1,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "additional_ids": [],
+            "rendering_provider_ids": [],
+            "allowed_amount": 99.56,
+            "remark_codes": [],
+            "provider_control_number": "123123123",
+            "healthcare_policy": [],
+            "adjustments": [
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "1",
+                "reason_label": "Deductible Amount",
+                "amount": 40.88,
+                "quantity": 0
+              },
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "3",
+                "reason_label": "Co-payment Amount",
+                "amount": 20,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "144",
+                "reason_label": "Incentive adjustment, e.g. preferred product/service.",
+                "amount": 4.98,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "45",
+                "reason_label": "Charge exceeds fee schedule/maximum allowable or contracted/legislated fee arrangement. (Use only with Group Codes PR or CO depending upon liability)",
+                "amount": 45.44,
+                "quantity": 0
+              }
+            ]
+          }
+        ]
+      },
+      "reference_id": "8KA1O09BR4QP7G"
+    },
+    {
+      "effective_date": "2016-04-15",
+      "payer": {
+        "name": "BCBSM",
+        "id": "ELIG_SNDBX",
+        "address": {
+          "street_line_1": "600 E LAFAYETTE",
+          "street_line_2": null,
+          "city": "DETROIT",
+          "state": "MI",
+          "zip": "482260000"
+        },
+        "contacts": [
+          {
+            "department_code": "CX",
+            "department_label": "Payers Claim Office. Location responsible for paying bills related to medical care received",
+            "name": "EDI HELPDESK",
+            "details": [
+              {
+                "type_code": "TE",
+                "type_label": "Telephone",
+                "value": "8005420945"
+              },
+              {
+                "type_code": "FX",
+                "type_label": "Facsimile",
+                "value": "2484862453"
+              }
+            ]
+          },
+          {
+            "department_code": "BL",
+            "department_label": "Technical Department",
+            "name": "EDI HELPDESK",
+            "details": [
+              {
+                "type_code": "TE",
+                "type_label": "Telephone",
+                "value": "8005420945"
+              },
+              {
+                "type_code": "FX",
+                "type_label": "Facsimile",
+                "value": "2484862453"
+              },
+              {
+                "type_code": "EM",
+                "type_label": "Electronic Mail",
+                "value": "EDI@BCBSM.COM"
+              }
+            ]
+          }
+        ],
+        "crossover_payer": null,
+        "corrected_priority_payer": null
+      },
+      "financials": {
+        "type_code": "I",
+        "type_label": "Remittance Information Only",
+        "total_payment_amount": "1261.03",
+        "credit": true,
+        "debit": false,
+        "payment_method_code": "ACH",
+        "payment_method_label": "Automated Clearing House (ACH)",
+        "payment_format_code": "CCP",
+        "payment_format_label": "Cash Concentration/Disbursement plus Addenda (CCD+) (ACH)",
+        "payment_date": "2016-02-03",
+        "payment_trace_number": "710618145",
+        "sender": {
+          "dfi_id_qualifier": "01",
+          "dfi_id_qualifier_label": "ABA Transit Routing Number Including Check Digits (9 digits)",
+          "dfi_id": "091000019",
+          "account_number": "1382069753",
+          "id": "1382069753",
+          "supplemental_code": ""
+        },
+        "receiver": {
+          "dfi_id_qualifier": "01",
+          "dfi_id_qualifier_label": "ABA Transit Routing Number Including Check Digits (9 digits)",
+          "dfi_id": "072000096",
+          "account_type": "Demand Deposit",
+          "account_number": "1852205283"
+        }
+      },
+      "payee": {
+        "name": "JENNIFER DESCHRYVER INC",
+        "npi": "1932382397",
+        "address": {
+          "street_line_1": null,
+          "street_line_2": null,
+          "city": "BLOOMFLD HLS",
+          "state": "MI",
+          "zip": "483013068"
+        },
+        "additional_ids": [
+          {
+            "type_code": "TJ",
+            "type_label": "Federal Taxpayer's Identification Number",
+            "value": "123123123"
+          }
+        ],
+        "adjustments": [],
+        "delivery_method": null
+      },
+      "patient": {
+        "first_name": "*****MIN",
+        "last_name": "*****LIN",
+        "middle_name": "J",
+        "id": "*******890"
+      },
+      "corrected_patient": {
+        "first_name": null,
+        "last_name": null,
+        "middle_name": null,
+        "id": null
+      },
+      "other_patient": {
+        "first_name": null,
+        "last_name": null,
+        "middle_name": null,
+        "id": null
+      },
+      "service_provider": null,
+      "claim": {
+        "control_number": "26160262372500710",
+        "received_date": "2016-04-15",
+        "expiration_date": null,
+        "filing_indicator_type": "12",
+        "filing_indicator_label": "Preferred Provider Organization (PPO)",
+        "place_of_service": "11",
+        "frequency": "1",
+        "responsibility_sequence": "primary",
+        "status": [
+          "processed"
+        ],
+        "drg_code": null,
+        "drg_quantity": null,
+        "amount": {
+          "billed": 435,
+          "paid": 33.7,
+          "patient_responsibility": 260,
+          "total_coverage": 298.68,
+          "prompt_payment_discount": null,
+          "per_day_limit": null,
+          "patient_paid": null,
+          "revised_interest": null,
+          "negative_ledger_balance": null,
+          "tax": null,
+          "total_claim_before_taxes": null,
+          "federal": {
+            "category_1": null,
+            "category_2": null,
+            "category_3": null,
+            "category_4": null,
+            "category_5": null
+          }
+        },
+        "adjustments": [],
+        "quantity": {
+          "actual": {
+            "covered": null,
+            "co_insured": null,
+            "life_time_reserve": null
+          },
+          "estimated": {
+            "life_time_reserve": null,
+            "non_covered": null
+          },
+          "not_replaced_blood_unit": null,
+          "outlier_days": null,
+          "prescription": null,
+          "visits": null,
+          "federal": {
+            "category_1": null,
+            "category_2": null,
+            "category_3": null,
+            "category_4": null,
+            "category_5": null
+          }
+        },
+        "additional_ids": [],
+        "rendering_provider_ids": [],
+        "moa_codes": [],
+        "allowed_amount": 298.68,
+        "contacts": [],
+        "service_lines": [
+          {
+            "procedure_qualifier": "HC<90834",
+            "procedure_code": null,
+            "procedure_modifiers": [],
+            "revenue_code": "",
+            "service_start": "2016-04-15",
+            "service_end": "2016-04-15",
+            "amount": {
+              "billed": 145,
+              "paid": 0,
+              "total_coverage": 99.56,
+              "deduction": null,
+              "tax": null,
+              "total_claim_before_taxes": null,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "quantity": {
+              "billed": 0,
+              "paid": 1,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "additional_ids": [],
+            "rendering_provider_ids": [],
+            "allowed_amount": 99.56,
+            "remark_codes": [],
+            "provider_control_number": "123123123",
+            "healthcare_policy": [],
+            "adjustments": [
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "1",
+                "reason_label": "Deductible Amount",
+                "amount": 79.56,
+                "quantity": 0
+              },
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "3",
+                "reason_label": "Co-payment Amount",
+                "amount": 20,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "45",
+                "reason_label": "Charge exceeds fee schedule/maximum allowable or contracted/legislated fee arrangement. (Use only with Group Codes PR or CO depending upon liability)",
+                "amount": 45.44,
+                "quantity": 0
+              }
+            ]
+          },
+          {
+            "procedure_qualifier": "HC<90834",
+            "procedure_code": null,
+            "procedure_modifiers": [],
+            "revenue_code": "",
+            "service_start": "2016-04-15",
+            "service_end": "2016-04-15",
+            "amount": {
+              "billed": 145,
+              "paid": 0,
+              "total_coverage": 99.56,
+              "deduction": null,
+              "tax": null,
+              "total_claim_before_taxes": null,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "quantity": {
+              "billed": 0,
+              "paid": 1,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "additional_ids": [],
+            "rendering_provider_ids": [],
+            "allowed_amount": 99.56,
+            "remark_codes": [],
+            "provider_control_number": "123123123",
+            "healthcare_policy": [],
+            "adjustments": [
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "1",
+                "reason_label": "Deductible Amount",
+                "amount": 79.56,
+                "quantity": 0
+              },
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "3",
+                "reason_label": "Co-payment Amount",
+                "amount": 20,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "45",
+                "reason_label": "Charge exceeds fee schedule/maximum allowable or contracted/legislated fee arrangement. (Use only with Group Codes PR or CO depending upon liability)",
+                "amount": 45.44,
+                "quantity": 0
+              }
+            ]
+          },
+          {
+            "procedure_qualifier": "HC<90834",
+            "procedure_code": null,
+            "procedure_modifiers": [],
+            "revenue_code": "",
+            "service_start": "2016-04-15",
+            "service_end": "2016-04-15",
+            "amount": {
+              "billed": 145,
+              "paid": 33.7,
+              "total_coverage": 99.56,
+              "deduction": null,
+              "tax": null,
+              "total_claim_before_taxes": null,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "quantity": {
+              "billed": 0,
+              "paid": 1,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "additional_ids": [],
+            "rendering_provider_ids": [],
+            "allowed_amount": 99.56,
+            "remark_codes": [],
+            "provider_control_number": "123123123",
+            "healthcare_policy": [],
+            "adjustments": [
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "1",
+                "reason_label": "Deductible Amount",
+                "amount": 40.88,
+                "quantity": 0
+              },
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "3",
+                "reason_label": "Co-payment Amount",
+                "amount": 20,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "144",
+                "reason_label": "Incentive adjustment, e.g. preferred product/service.",
+                "amount": 4.98,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "45",
+                "reason_label": "Charge exceeds fee schedule/maximum allowable or contracted/legislated fee arrangement. (Use only with Group Codes PR or CO depending upon liability)",
+                "amount": 45.44,
+                "quantity": 0
+              }
+            ]
+          }
+        ]
+      },
+      "reference_id": "8KA1O09BR4QP7G"
+    },
+    {
+      "effective_date": "2016-04-15",
+      "payer": {
+        "name": "BCBSM",
+        "id": "ELIG_SNDBX",
+        "address": {
+          "street_line_1": "600 E LAFAYETTE",
+          "street_line_2": null,
+          "city": "DETROIT",
+          "state": "MI",
+          "zip": "482260000"
+        },
+        "contacts": [
+          {
+            "department_code": "CX",
+            "department_label": "Payers Claim Office. Location responsible for paying bills related to medical care received",
+            "name": "EDI HELPDESK",
+            "details": [
+              {
+                "type_code": "TE",
+                "type_label": "Telephone",
+                "value": "8005420945"
+              },
+              {
+                "type_code": "FX",
+                "type_label": "Facsimile",
+                "value": "2484862453"
+              }
+            ]
+          },
+          {
+            "department_code": "BL",
+            "department_label": "Technical Department",
+            "name": "EDI HELPDESK",
+            "details": [
+              {
+                "type_code": "TE",
+                "type_label": "Telephone",
+                "value": "8005420945"
+              },
+              {
+                "type_code": "FX",
+                "type_label": "Facsimile",
+                "value": "2484862453"
+              },
+              {
+                "type_code": "EM",
+                "type_label": "Electronic Mail",
+                "value": "EDI@BCBSM.COM"
+              }
+            ]
+          }
+        ],
+        "crossover_payer": null,
+        "corrected_priority_payer": null
+      },
+      "financials": {
+        "type_code": "I",
+        "type_label": "Remittance Information Only",
+        "total_payment_amount": "1261.03",
+        "credit": true,
+        "debit": false,
+        "payment_method_code": "ACH",
+        "payment_method_label": "Automated Clearing House (ACH)",
+        "payment_format_code": "CCP",
+        "payment_format_label": "Cash Concentration/Disbursement plus Addenda (CCD+) (ACH)",
+        "payment_date": "2016-02-03",
+        "payment_trace_number": "710618145",
+        "sender": {
+          "dfi_id_qualifier": "01",
+          "dfi_id_qualifier_label": "ABA Transit Routing Number Including Check Digits (9 digits)",
+          "dfi_id": "091000019",
+          "account_number": "1382069753",
+          "id": "1382069753",
+          "supplemental_code": ""
+        },
+        "receiver": {
+          "dfi_id_qualifier": "01",
+          "dfi_id_qualifier_label": "ABA Transit Routing Number Including Check Digits (9 digits)",
+          "dfi_id": "072000096",
+          "account_type": "Demand Deposit",
+          "account_number": "1852205283"
+        }
+      },
+      "payee": {
+        "name": "JENNIFER DESCHRYVER INC",
+        "npi": "1932382397",
+        "address": {
+          "street_line_1": null,
+          "street_line_2": null,
+          "city": "BLOOMFLD HLS",
+          "state": "MI",
+          "zip": "483013068"
+        },
+        "additional_ids": [
+          {
+            "type_code": "TJ",
+            "type_label": "Federal Taxpayer's Identification Number",
+            "value": "123123123"
+          }
+        ],
+        "adjustments": [],
+        "delivery_method": null
+      },
+      "patient": {
+        "first_name": "*****MIN",
+        "last_name": "*****LIN",
+        "middle_name": "J",
+        "id": "*******890"
+      },
+      "corrected_patient": {
+        "first_name": null,
+        "last_name": null,
+        "middle_name": null,
+        "id": null
+      },
+      "other_patient": {
+        "first_name": null,
+        "last_name": null,
+        "middle_name": null,
+        "id": null
+      },
+      "service_provider": null,
+      "claim": {
+        "control_number": "26160262372500710",
+        "received_date": "2016-04-15",
+        "expiration_date": null,
+        "filing_indicator_type": "12",
+        "filing_indicator_label": "Preferred Provider Organization (PPO)",
+        "place_of_service": "11",
+        "frequency": "1",
+        "responsibility_sequence": "primary",
+        "status": [
+          "processed"
+        ],
+        "drg_code": null,
+        "drg_quantity": null,
+        "amount": {
+          "billed": 435,
+          "paid": 33.7,
+          "patient_responsibility": 260,
+          "total_coverage": 298.68,
+          "prompt_payment_discount": null,
+          "per_day_limit": null,
+          "patient_paid": null,
+          "revised_interest": null,
+          "negative_ledger_balance": null,
+          "tax": null,
+          "total_claim_before_taxes": null,
+          "federal": {
+            "category_1": null,
+            "category_2": null,
+            "category_3": null,
+            "category_4": null,
+            "category_5": null
+          }
+        },
+        "adjustments": [],
+        "quantity": {
+          "actual": {
+            "covered": null,
+            "co_insured": null,
+            "life_time_reserve": null
+          },
+          "estimated": {
+            "life_time_reserve": null,
+            "non_covered": null
+          },
+          "not_replaced_blood_unit": null,
+          "outlier_days": null,
+          "prescription": null,
+          "visits": null,
+          "federal": {
+            "category_1": null,
+            "category_2": null,
+            "category_3": null,
+            "category_4": null,
+            "category_5": null
+          }
+        },
+        "additional_ids": [],
+        "rendering_provider_ids": [],
+        "moa_codes": [],
+        "allowed_amount": 298.68,
+        "contacts": [],
+        "service_lines": [
+          {
+            "procedure_qualifier": "HC<90834",
+            "procedure_code": null,
+            "procedure_modifiers": [],
+            "revenue_code": "",
+            "service_start": "2016-04-15",
+            "service_end": "2016-04-15",
+            "amount": {
+              "billed": 145,
+              "paid": 0,
+              "total_coverage": 99.56,
+              "deduction": null,
+              "tax": null,
+              "total_claim_before_taxes": null,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "quantity": {
+              "billed": 0,
+              "paid": 1,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "additional_ids": [],
+            "rendering_provider_ids": [],
+            "allowed_amount": 99.56,
+            "remark_codes": [],
+            "provider_control_number": "123123123",
+            "healthcare_policy": [],
+            "adjustments": [
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "1",
+                "reason_label": "Deductible Amount",
+                "amount": 79.56,
+                "quantity": 0
+              },
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "3",
+                "reason_label": "Co-payment Amount",
+                "amount": 20,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "45",
+                "reason_label": "Charge exceeds fee schedule/maximum allowable or contracted/legislated fee arrangement. (Use only with Group Codes PR or CO depending upon liability)",
+                "amount": 45.44,
+                "quantity": 0
+              }
+            ]
+          },
+          {
+            "procedure_qualifier": "HC<90834",
+            "procedure_code": null,
+            "procedure_modifiers": [],
+            "revenue_code": "",
+            "service_start": "2016-04-15",
+            "service_end": "2016-04-15",
+            "amount": {
+              "billed": 145,
+              "paid": 0,
+              "total_coverage": 99.56,
+              "deduction": null,
+              "tax": null,
+              "total_claim_before_taxes": null,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "quantity": {
+              "billed": 0,
+              "paid": 1,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "additional_ids": [],
+            "rendering_provider_ids": [],
+            "allowed_amount": 99.56,
+            "remark_codes": [],
+            "provider_control_number": "123123123",
+            "healthcare_policy": [],
+            "adjustments": [
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "1",
+                "reason_label": "Deductible Amount",
+                "amount": 79.56,
+                "quantity": 0
+              },
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "3",
+                "reason_label": "Co-payment Amount",
+                "amount": 20,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "45",
+                "reason_label": "Charge exceeds fee schedule/maximum allowable or contracted/legislated fee arrangement. (Use only with Group Codes PR or CO depending upon liability)",
+                "amount": 45.44,
+                "quantity": 0
+              }
+            ]
+          },
+          {
+            "procedure_qualifier": "HC<90834",
+            "procedure_code": null,
+            "procedure_modifiers": [],
+            "revenue_code": "",
+            "service_start": "2016-04-15",
+            "service_end": "2016-04-15",
+            "amount": {
+              "billed": 145,
+              "paid": 33.7,
+              "total_coverage": 99.56,
+              "deduction": null,
+              "tax": null,
+              "total_claim_before_taxes": null,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "quantity": {
+              "billed": 0,
+              "paid": 1,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "additional_ids": [],
+            "rendering_provider_ids": [],
+            "allowed_amount": 99.56,
+            "remark_codes": [],
+            "provider_control_number": "123123123",
+            "healthcare_policy": [],
+            "adjustments": [
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "1",
+                "reason_label": "Deductible Amount",
+                "amount": 40.88,
+                "quantity": 0
+              },
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "3",
+                "reason_label": "Co-payment Amount",
+                "amount": 20,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "144",
+                "reason_label": "Incentive adjustment, e.g. preferred product/service.",
+                "amount": 4.98,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "45",
+                "reason_label": "Charge exceeds fee schedule/maximum allowable or contracted/legislated fee arrangement. (Use only with Group Codes PR or CO depending upon liability)",
+                "amount": 45.44,
+                "quantity": 0
+              }
+            ]
+          }
+        ]
+      },
+      "reference_id": "UTSYSRZ0ZCGG5"
+    },
+    {
+      "effective_date": "2016-04-15",
+      "payer": {
+        "name": "BCBSM",
+        "id": "ELIG_SNDBX",
+        "address": {
+          "street_line_1": "600 E LAFAYETTE",
+          "street_line_2": null,
+          "city": "DETROIT",
+          "state": "MI",
+          "zip": "482260000"
+        },
+        "contacts": [
+          {
+            "department_code": "CX",
+            "department_label": "Payers Claim Office. Location responsible for paying bills related to medical care received",
+            "name": "EDI HELPDESK",
+            "details": [
+              {
+                "type_code": "TE",
+                "type_label": "Telephone",
+                "value": "8005420945"
+              },
+              {
+                "type_code": "FX",
+                "type_label": "Facsimile",
+                "value": "2484862453"
+              }
+            ]
+          },
+          {
+            "department_code": "BL",
+            "department_label": "Technical Department",
+            "name": "EDI HELPDESK",
+            "details": [
+              {
+                "type_code": "TE",
+                "type_label": "Telephone",
+                "value": "8005420945"
+              },
+              {
+                "type_code": "FX",
+                "type_label": "Facsimile",
+                "value": "2484862453"
+              },
+              {
+                "type_code": "EM",
+                "type_label": "Electronic Mail",
+                "value": "EDI@BCBSM.COM"
+              }
+            ]
+          }
+        ],
+        "crossover_payer": null,
+        "corrected_priority_payer": null
+      },
+      "financials": {
+        "type_code": "I",
+        "type_label": "Remittance Information Only",
+        "total_payment_amount": "1261.03",
+        "credit": true,
+        "debit": false,
+        "payment_method_code": "ACH",
+        "payment_method_label": "Automated Clearing House (ACH)",
+        "payment_format_code": "CCP",
+        "payment_format_label": "Cash Concentration/Disbursement plus Addenda (CCD+) (ACH)",
+        "payment_date": "2016-02-03",
+        "payment_trace_number": "710618145",
+        "sender": {
+          "dfi_id_qualifier": "01",
+          "dfi_id_qualifier_label": "ABA Transit Routing Number Including Check Digits (9 digits)",
+          "dfi_id": "091000019",
+          "account_number": "1382069753",
+          "id": "1382069753",
+          "supplemental_code": ""
+        },
+        "receiver": {
+          "dfi_id_qualifier": "01",
+          "dfi_id_qualifier_label": "ABA Transit Routing Number Including Check Digits (9 digits)",
+          "dfi_id": "072000096",
+          "account_type": "Demand Deposit",
+          "account_number": "1852205283"
+        }
+      },
+      "payee": {
+        "name": "JENNIFER DESCHRYVER INC",
+        "npi": "1932382397",
+        "address": {
+          "street_line_1": null,
+          "street_line_2": null,
+          "city": "BLOOMFLD HLS",
+          "state": "MI",
+          "zip": "483013068"
+        },
+        "additional_ids": [
+          {
+            "type_code": "TJ",
+            "type_label": "Federal Taxpayer's Identification Number",
+            "value": "123123123"
+          }
+        ],
+        "adjustments": [],
+        "delivery_method": null
+      },
+      "patient": {
+        "first_name": "*****MIN",
+        "last_name": "*****LIN",
+        "middle_name": "J",
+        "id": "*******890"
+      },
+      "corrected_patient": {
+        "first_name": null,
+        "last_name": null,
+        "middle_name": null,
+        "id": null
+      },
+      "other_patient": {
+        "first_name": null,
+        "last_name": null,
+        "middle_name": null,
+        "id": null
+      },
+      "service_provider": null,
+      "claim": {
+        "control_number": "26160262372500710",
+        "received_date": "2016-04-15",
+        "expiration_date": null,
+        "filing_indicator_type": "12",
+        "filing_indicator_label": "Preferred Provider Organization (PPO)",
+        "place_of_service": "11",
+        "frequency": "1",
+        "responsibility_sequence": "primary",
+        "status": [
+          "processed"
+        ],
+        "drg_code": null,
+        "drg_quantity": null,
+        "amount": {
+          "billed": 435,
+          "paid": 33.7,
+          "patient_responsibility": 260,
+          "total_coverage": 298.68,
+          "prompt_payment_discount": null,
+          "per_day_limit": null,
+          "patient_paid": null,
+          "revised_interest": null,
+          "negative_ledger_balance": null,
+          "tax": null,
+          "total_claim_before_taxes": null,
+          "federal": {
+            "category_1": null,
+            "category_2": null,
+            "category_3": null,
+            "category_4": null,
+            "category_5": null
+          }
+        },
+        "adjustments": [],
+        "quantity": {
+          "actual": {
+            "covered": null,
+            "co_insured": null,
+            "life_time_reserve": null
+          },
+          "estimated": {
+            "life_time_reserve": null,
+            "non_covered": null
+          },
+          "not_replaced_blood_unit": null,
+          "outlier_days": null,
+          "prescription": null,
+          "visits": null,
+          "federal": {
+            "category_1": null,
+            "category_2": null,
+            "category_3": null,
+            "category_4": null,
+            "category_5": null
+          }
+        },
+        "additional_ids": [],
+        "rendering_provider_ids": [],
+        "moa_codes": [],
+        "allowed_amount": 298.68,
+        "contacts": [],
+        "service_lines": [
+          {
+            "procedure_qualifier": "HC<90834",
+            "procedure_code": null,
+            "procedure_modifiers": [],
+            "revenue_code": "",
+            "service_start": "2016-04-15",
+            "service_end": "2016-04-15",
+            "amount": {
+              "billed": 145,
+              "paid": 0,
+              "total_coverage": 99.56,
+              "deduction": null,
+              "tax": null,
+              "total_claim_before_taxes": null,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "quantity": {
+              "billed": 0,
+              "paid": 1,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "additional_ids": [],
+            "rendering_provider_ids": [],
+            "allowed_amount": 99.56,
+            "remark_codes": [],
+            "provider_control_number": "123123123",
+            "healthcare_policy": [],
+            "adjustments": [
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "1",
+                "reason_label": "Deductible Amount",
+                "amount": 79.56,
+                "quantity": 0
+              },
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "3",
+                "reason_label": "Co-payment Amount",
+                "amount": 20,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "45",
+                "reason_label": "Charge exceeds fee schedule/maximum allowable or contracted/legislated fee arrangement. (Use only with Group Codes PR or CO depending upon liability)",
+                "amount": 45.44,
+                "quantity": 0
+              }
+            ]
+          },
+          {
+            "procedure_qualifier": "HC<90834",
+            "procedure_code": null,
+            "procedure_modifiers": [],
+            "revenue_code": "",
+            "service_start": "2016-04-15",
+            "service_end": "2016-04-15",
+            "amount": {
+              "billed": 145,
+              "paid": 0,
+              "total_coverage": 99.56,
+              "deduction": null,
+              "tax": null,
+              "total_claim_before_taxes": null,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "quantity": {
+              "billed": 0,
+              "paid": 1,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "additional_ids": [],
+            "rendering_provider_ids": [],
+            "allowed_amount": 99.56,
+            "remark_codes": [],
+            "provider_control_number": "123123123",
+            "healthcare_policy": [],
+            "adjustments": [
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "1",
+                "reason_label": "Deductible Amount",
+                "amount": 79.56,
+                "quantity": 0
+              },
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "3",
+                "reason_label": "Co-payment Amount",
+                "amount": 20,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "45",
+                "reason_label": "Charge exceeds fee schedule/maximum allowable or contracted/legislated fee arrangement. (Use only with Group Codes PR or CO depending upon liability)",
+                "amount": 45.44,
+                "quantity": 0
+              }
+            ]
+          },
+          {
+            "procedure_qualifier": "HC<90834",
+            "procedure_code": null,
+            "procedure_modifiers": [],
+            "revenue_code": "",
+            "service_start": "2016-04-15",
+            "service_end": "2016-04-15",
+            "amount": {
+              "billed": 145,
+              "paid": 33.7,
+              "total_coverage": 99.56,
+              "deduction": null,
+              "tax": null,
+              "total_claim_before_taxes": null,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "quantity": {
+              "billed": 0,
+              "paid": 1,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "additional_ids": [],
+            "rendering_provider_ids": [],
+            "allowed_amount": 99.56,
+            "remark_codes": [],
+            "provider_control_number": "123123123",
+            "healthcare_policy": [],
+            "adjustments": [
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "1",
+                "reason_label": "Deductible Amount",
+                "amount": 40.88,
+                "quantity": 0
+              },
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "3",
+                "reason_label": "Co-payment Amount",
+                "amount": 20,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "144",
+                "reason_label": "Incentive adjustment, e.g. preferred product/service.",
+                "amount": 4.98,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "45",
+                "reason_label": "Charge exceeds fee schedule/maximum allowable or contracted/legislated fee arrangement. (Use only with Group Codes PR or CO depending upon liability)",
+                "amount": 45.44,
+                "quantity": 0
+              }
+            ]
+          }
+        ]
+      },
+      "reference_id": "UTSNTFOBRGDVP"
+    },
+    {
+      "effective_date": "2016-04-15",
+      "payer": {
+        "name": "BCBSM",
+        "id": "ELIG_SNDBX",
+        "address": {
+          "street_line_1": "600 E LAFAYETTE",
+          "street_line_2": null,
+          "city": "DETROIT",
+          "state": "MI",
+          "zip": "482260000"
+        },
+        "contacts": [
+          {
+            "department_code": "CX",
+            "department_label": "Payers Claim Office. Location responsible for paying bills related to medical care received",
+            "name": "EDI HELPDESK",
+            "details": [
+              {
+                "type_code": "TE",
+                "type_label": "Telephone",
+                "value": "8005420945"
+              },
+              {
+                "type_code": "FX",
+                "type_label": "Facsimile",
+                "value": "2484862453"
+              }
+            ]
+          },
+          {
+            "department_code": "BL",
+            "department_label": "Technical Department",
+            "name": "EDI HELPDESK",
+            "details": [
+              {
+                "type_code": "TE",
+                "type_label": "Telephone",
+                "value": "8005420945"
+              },
+              {
+                "type_code": "FX",
+                "type_label": "Facsimile",
+                "value": "2484862453"
+              },
+              {
+                "type_code": "EM",
+                "type_label": "Electronic Mail",
+                "value": "EDI@BCBSM.COM"
+              }
+            ]
+          }
+        ],
+        "crossover_payer": null,
+        "corrected_priority_payer": null
+      },
+      "financials": {
+        "type_code": "I",
+        "type_label": "Remittance Information Only",
+        "total_payment_amount": "1261.03",
+        "credit": true,
+        "debit": false,
+        "payment_method_code": "ACH",
+        "payment_method_label": "Automated Clearing House (ACH)",
+        "payment_format_code": "CCP",
+        "payment_format_label": "Cash Concentration/Disbursement plus Addenda (CCD+) (ACH)",
+        "payment_date": "2016-02-03",
+        "payment_trace_number": "710618145",
+        "sender": {
+          "dfi_id_qualifier": "01",
+          "dfi_id_qualifier_label": "ABA Transit Routing Number Including Check Digits (9 digits)",
+          "dfi_id": "091000019",
+          "account_number": "1382069753",
+          "id": "1382069753",
+          "supplemental_code": ""
+        },
+        "receiver": {
+          "dfi_id_qualifier": "01",
+          "dfi_id_qualifier_label": "ABA Transit Routing Number Including Check Digits (9 digits)",
+          "dfi_id": "072000096",
+          "account_type": "Demand Deposit",
+          "account_number": "1852205283"
+        }
+      },
+      "payee": {
+        "name": "JENNIFER DESCHRYVER INC",
+        "npi": "1932382397",
+        "address": {
+          "street_line_1": null,
+          "street_line_2": null,
+          "city": "BLOOMFLD HLS",
+          "state": "MI",
+          "zip": "483013068"
+        },
+        "additional_ids": [
+          {
+            "type_code": "TJ",
+            "type_label": "Federal Taxpayer's Identification Number",
+            "value": "123123123"
+          }
+        ],
+        "adjustments": [],
+        "delivery_method": null
+      },
+      "patient": {
+        "first_name": "*****MIN",
+        "last_name": "*****LIN",
+        "middle_name": "J",
+        "id": "*******890"
+      },
+      "corrected_patient": {
+        "first_name": null,
+        "last_name": null,
+        "middle_name": null,
+        "id": null
+      },
+      "other_patient": {
+        "first_name": null,
+        "last_name": null,
+        "middle_name": null,
+        "id": null
+      },
+      "service_provider": null,
+      "claim": {
+        "control_number": "26160262372500710",
+        "received_date": "2016-04-15",
+        "expiration_date": null,
+        "filing_indicator_type": "12",
+        "filing_indicator_label": "Preferred Provider Organization (PPO)",
+        "place_of_service": "11",
+        "frequency": "1",
+        "responsibility_sequence": "primary",
+        "status": [
+          "processed"
+        ],
+        "drg_code": null,
+        "drg_quantity": null,
+        "amount": {
+          "billed": 435,
+          "paid": 33.7,
+          "patient_responsibility": 260,
+          "total_coverage": 298.68,
+          "prompt_payment_discount": null,
+          "per_day_limit": null,
+          "patient_paid": null,
+          "revised_interest": null,
+          "negative_ledger_balance": null,
+          "tax": null,
+          "total_claim_before_taxes": null,
+          "federal": {
+            "category_1": null,
+            "category_2": null,
+            "category_3": null,
+            "category_4": null,
+            "category_5": null
+          }
+        },
+        "adjustments": [],
+        "quantity": {
+          "actual": {
+            "covered": null,
+            "co_insured": null,
+            "life_time_reserve": null
+          },
+          "estimated": {
+            "life_time_reserve": null,
+            "non_covered": null
+          },
+          "not_replaced_blood_unit": null,
+          "outlier_days": null,
+          "prescription": null,
+          "visits": null,
+          "federal": {
+            "category_1": null,
+            "category_2": null,
+            "category_3": null,
+            "category_4": null,
+            "category_5": null
+          }
+        },
+        "additional_ids": [],
+        "rendering_provider_ids": [],
+        "moa_codes": [],
+        "allowed_amount": 298.68,
+        "contacts": [],
+        "service_lines": [
+          {
+            "procedure_qualifier": "HC<90834",
+            "procedure_code": null,
+            "procedure_modifiers": [],
+            "revenue_code": "",
+            "service_start": "2016-04-15",
+            "service_end": "2016-04-15",
+            "amount": {
+              "billed": 145,
+              "paid": 0,
+              "total_coverage": 99.56,
+              "deduction": null,
+              "tax": null,
+              "total_claim_before_taxes": null,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "quantity": {
+              "billed": 0,
+              "paid": 1,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "additional_ids": [],
+            "rendering_provider_ids": [],
+            "allowed_amount": 99.56,
+            "remark_codes": [],
+            "provider_control_number": "123123123",
+            "healthcare_policy": [],
+            "adjustments": [
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "1",
+                "reason_label": "Deductible Amount",
+                "amount": 79.56,
+                "quantity": 0
+              },
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "3",
+                "reason_label": "Co-payment Amount",
+                "amount": 20,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "45",
+                "reason_label": "Charge exceeds fee schedule/maximum allowable or contracted/legislated fee arrangement. (Use only with Group Codes PR or CO depending upon liability)",
+                "amount": 45.44,
+                "quantity": 0
+              }
+            ]
+          },
+          {
+            "procedure_qualifier": "HC<90834",
+            "procedure_code": null,
+            "procedure_modifiers": [],
+            "revenue_code": "",
+            "service_start": "2016-04-15",
+            "service_end": "2016-04-15",
+            "amount": {
+              "billed": 145,
+              "paid": 0,
+              "total_coverage": 99.56,
+              "deduction": null,
+              "tax": null,
+              "total_claim_before_taxes": null,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "quantity": {
+              "billed": 0,
+              "paid": 1,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "additional_ids": [],
+            "rendering_provider_ids": [],
+            "allowed_amount": 99.56,
+            "remark_codes": [],
+            "provider_control_number": "123123123",
+            "healthcare_policy": [],
+            "adjustments": [
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "1",
+                "reason_label": "Deductible Amount",
+                "amount": 79.56,
+                "quantity": 0
+              },
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "3",
+                "reason_label": "Co-payment Amount",
+                "amount": 20,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "45",
+                "reason_label": "Charge exceeds fee schedule/maximum allowable or contracted/legislated fee arrangement. (Use only with Group Codes PR or CO depending upon liability)",
+                "amount": 45.44,
+                "quantity": 0
+              }
+            ]
+          },
+          {
+            "procedure_qualifier": "HC<90834",
+            "procedure_code": null,
+            "procedure_modifiers": [],
+            "revenue_code": "",
+            "service_start": "2016-04-15",
+            "service_end": "2016-04-15",
+            "amount": {
+              "billed": 145,
+              "paid": 33.7,
+              "total_coverage": 99.56,
+              "deduction": null,
+              "tax": null,
+              "total_claim_before_taxes": null,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "quantity": {
+              "billed": 0,
+              "paid": 1,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "additional_ids": [],
+            "rendering_provider_ids": [],
+            "allowed_amount": 99.56,
+            "remark_codes": [],
+            "provider_control_number": "123123123",
+            "healthcare_policy": [],
+            "adjustments": [
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "1",
+                "reason_label": "Deductible Amount",
+                "amount": 40.88,
+                "quantity": 0
+              },
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "3",
+                "reason_label": "Co-payment Amount",
+                "amount": 20,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "144",
+                "reason_label": "Incentive adjustment, e.g. preferred product/service.",
+                "amount": 4.98,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "45",
+                "reason_label": "Charge exceeds fee schedule/maximum allowable or contracted/legislated fee arrangement. (Use only with Group Codes PR or CO depending upon liability)",
+                "amount": 45.44,
+                "quantity": 0
+              }
+            ]
+          }
+        ]
+      },
+      "reference_id": "UTSNTKN6268BG"
+    },
+    {
+      "effective_date": "2016-04-15",
+      "payer": {
+        "name": "BCBSM",
+        "id": "ELIG_SNDBX",
+        "address": {
+          "street_line_1": "600 E LAFAYETTE",
+          "street_line_2": null,
+          "city": "DETROIT",
+          "state": "MI",
+          "zip": "482260000"
+        },
+        "contacts": [
+          {
+            "department_code": "CX",
+            "department_label": "Payers Claim Office. Location responsible for paying bills related to medical care received",
+            "name": "EDI HELPDESK",
+            "details": [
+              {
+                "type_code": "TE",
+                "type_label": "Telephone",
+                "value": "8005420945"
+              },
+              {
+                "type_code": "FX",
+                "type_label": "Facsimile",
+                "value": "2484862453"
+              }
+            ]
+          },
+          {
+            "department_code": "BL",
+            "department_label": "Technical Department",
+            "name": "EDI HELPDESK",
+            "details": [
+              {
+                "type_code": "TE",
+                "type_label": "Telephone",
+                "value": "8005420945"
+              },
+              {
+                "type_code": "FX",
+                "type_label": "Facsimile",
+                "value": "2484862453"
+              },
+              {
+                "type_code": "EM",
+                "type_label": "Electronic Mail",
+                "value": "EDI@BCBSM.COM"
+              }
+            ]
+          }
+        ],
+        "crossover_payer": null,
+        "corrected_priority_payer": null
+      },
+      "financials": {
+        "type_code": "I",
+        "type_label": "Remittance Information Only",
+        "total_payment_amount": "1261.03",
+        "credit": true,
+        "debit": false,
+        "payment_method_code": "ACH",
+        "payment_method_label": "Automated Clearing House (ACH)",
+        "payment_format_code": "CCP",
+        "payment_format_label": "Cash Concentration/Disbursement plus Addenda (CCD+) (ACH)",
+        "payment_date": "2016-02-03",
+        "payment_trace_number": "710618145",
+        "sender": {
+          "dfi_id_qualifier": "01",
+          "dfi_id_qualifier_label": "ABA Transit Routing Number Including Check Digits (9 digits)",
+          "dfi_id": "091000019",
+          "account_number": "1382069753",
+          "id": "1382069753",
+          "supplemental_code": ""
+        },
+        "receiver": {
+          "dfi_id_qualifier": "01",
+          "dfi_id_qualifier_label": "ABA Transit Routing Number Including Check Digits (9 digits)",
+          "dfi_id": "072000096",
+          "account_type": "Demand Deposit",
+          "account_number": "1852205283"
+        }
+      },
+      "payee": {
+        "name": "JENNIFER DESCHRYVER INC",
+        "npi": "1932382397",
+        "address": {
+          "street_line_1": null,
+          "street_line_2": null,
+          "city": "BLOOMFLD HLS",
+          "state": "MI",
+          "zip": "483013068"
+        },
+        "additional_ids": [
+          {
+            "type_code": "TJ",
+            "type_label": "Federal Taxpayer's Identification Number",
+            "value": "123123123"
+          }
+        ],
+        "adjustments": [],
+        "delivery_method": null
+      },
+      "patient": {
+        "first_name": "*****MIN",
+        "last_name": "*****LIN",
+        "middle_name": "J",
+        "id": "*******890"
+      },
+      "corrected_patient": {
+        "first_name": null,
+        "last_name": null,
+        "middle_name": null,
+        "id": null
+      },
+      "other_patient": {
+        "first_name": null,
+        "last_name": null,
+        "middle_name": null,
+        "id": null
+      },
+      "service_provider": null,
+      "claim": {
+        "control_number": "26160262372500710",
+        "received_date": "2016-04-15",
+        "expiration_date": null,
+        "filing_indicator_type": "12",
+        "filing_indicator_label": "Preferred Provider Organization (PPO)",
+        "place_of_service": "11",
+        "frequency": "1",
+        "responsibility_sequence": "primary",
+        "status": [
+          "processed"
+        ],
+        "drg_code": null,
+        "drg_quantity": null,
+        "amount": {
+          "billed": 435,
+          "paid": 33.7,
+          "patient_responsibility": 260,
+          "total_coverage": 298.68,
+          "prompt_payment_discount": null,
+          "per_day_limit": null,
+          "patient_paid": null,
+          "revised_interest": null,
+          "negative_ledger_balance": null,
+          "tax": null,
+          "total_claim_before_taxes": null,
+          "federal": {
+            "category_1": null,
+            "category_2": null,
+            "category_3": null,
+            "category_4": null,
+            "category_5": null
+          }
+        },
+        "adjustments": [],
+        "quantity": {
+          "actual": {
+            "covered": null,
+            "co_insured": null,
+            "life_time_reserve": null
+          },
+          "estimated": {
+            "life_time_reserve": null,
+            "non_covered": null
+          },
+          "not_replaced_blood_unit": null,
+          "outlier_days": null,
+          "prescription": null,
+          "visits": null,
+          "federal": {
+            "category_1": null,
+            "category_2": null,
+            "category_3": null,
+            "category_4": null,
+            "category_5": null
+          }
+        },
+        "additional_ids": [],
+        "rendering_provider_ids": [],
+        "moa_codes": [],
+        "allowed_amount": 298.68,
+        "contacts": [],
+        "service_lines": [
+          {
+            "procedure_qualifier": "HC<90834",
+            "procedure_code": null,
+            "procedure_modifiers": [],
+            "revenue_code": "",
+            "service_start": "2016-04-15",
+            "service_end": "2016-04-15",
+            "amount": {
+              "billed": 145,
+              "paid": 0,
+              "total_coverage": 99.56,
+              "deduction": null,
+              "tax": null,
+              "total_claim_before_taxes": null,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "quantity": {
+              "billed": 0,
+              "paid": 1,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "additional_ids": [],
+            "rendering_provider_ids": [],
+            "allowed_amount": 99.56,
+            "remark_codes": [],
+            "provider_control_number": "123123123",
+            "healthcare_policy": [],
+            "adjustments": [
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "1",
+                "reason_label": "Deductible Amount",
+                "amount": 79.56,
+                "quantity": 0
+              },
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "3",
+                "reason_label": "Co-payment Amount",
+                "amount": 20,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "45",
+                "reason_label": "Charge exceeds fee schedule/maximum allowable or contracted/legislated fee arrangement. (Use only with Group Codes PR or CO depending upon liability)",
+                "amount": 45.44,
+                "quantity": 0
+              }
+            ]
+          },
+          {
+            "procedure_qualifier": "HC<90834",
+            "procedure_code": null,
+            "procedure_modifiers": [],
+            "revenue_code": "",
+            "service_start": "2016-04-15",
+            "service_end": "2016-04-15",
+            "amount": {
+              "billed": 145,
+              "paid": 0,
+              "total_coverage": 99.56,
+              "deduction": null,
+              "tax": null,
+              "total_claim_before_taxes": null,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "quantity": {
+              "billed": 0,
+              "paid": 1,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "additional_ids": [],
+            "rendering_provider_ids": [],
+            "allowed_amount": 99.56,
+            "remark_codes": [],
+            "provider_control_number": "123123123",
+            "healthcare_policy": [],
+            "adjustments": [
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "1",
+                "reason_label": "Deductible Amount",
+                "amount": 79.56,
+                "quantity": 0
+              },
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "3",
+                "reason_label": "Co-payment Amount",
+                "amount": 20,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "45",
+                "reason_label": "Charge exceeds fee schedule/maximum allowable or contracted/legislated fee arrangement. (Use only with Group Codes PR or CO depending upon liability)",
+                "amount": 45.44,
+                "quantity": 0
+              }
+            ]
+          },
+          {
+            "procedure_qualifier": "HC<90834",
+            "procedure_code": null,
+            "procedure_modifiers": [],
+            "revenue_code": "",
+            "service_start": "2016-04-15",
+            "service_end": "2016-04-15",
+            "amount": {
+              "billed": 145,
+              "paid": 33.7,
+              "total_coverage": 99.56,
+              "deduction": null,
+              "tax": null,
+              "total_claim_before_taxes": null,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "quantity": {
+              "billed": 0,
+              "paid": 1,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "additional_ids": [],
+            "rendering_provider_ids": [],
+            "allowed_amount": 99.56,
+            "remark_codes": [],
+            "provider_control_number": "123123123",
+            "healthcare_policy": [],
+            "adjustments": [
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "1",
+                "reason_label": "Deductible Amount",
+                "amount": 40.88,
+                "quantity": 0
+              },
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "3",
+                "reason_label": "Co-payment Amount",
+                "amount": 20,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "144",
+                "reason_label": "Incentive adjustment, e.g. preferred product/service.",
+                "amount": 4.98,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "45",
+                "reason_label": "Charge exceeds fee schedule/maximum allowable or contracted/legislated fee arrangement. (Use only with Group Codes PR or CO depending upon liability)",
+                "amount": 45.44,
+                "quantity": 0
+              }
+            ]
+          }
+        ]
+      },
+      "reference_id": "8K9YM79BVDDYEO"
+    },
+    {
+      "effective_date": "2016-04-15",
+      "payer": {
+        "name": "BCBSM",
+        "id": "ELIG_SNDBX",
+        "address": {
+          "street_line_1": "600 E LAFAYETTE",
+          "street_line_2": null,
+          "city": "DETROIT",
+          "state": "MI",
+          "zip": "482260000"
+        },
+        "contacts": [
+          {
+            "department_code": "CX",
+            "department_label": "Payers Claim Office. Location responsible for paying bills related to medical care received",
+            "name": "EDI HELPDESK",
+            "details": [
+              {
+                "type_code": "TE",
+                "type_label": "Telephone",
+                "value": "8005420945"
+              },
+              {
+                "type_code": "FX",
+                "type_label": "Facsimile",
+                "value": "2484862453"
+              }
+            ]
+          },
+          {
+            "department_code": "BL",
+            "department_label": "Technical Department",
+            "name": "EDI HELPDESK",
+            "details": [
+              {
+                "type_code": "TE",
+                "type_label": "Telephone",
+                "value": "8005420945"
+              },
+              {
+                "type_code": "FX",
+                "type_label": "Facsimile",
+                "value": "2484862453"
+              },
+              {
+                "type_code": "EM",
+                "type_label": "Electronic Mail",
+                "value": "EDI@BCBSM.COM"
+              }
+            ]
+          }
+        ],
+        "crossover_payer": null,
+        "corrected_priority_payer": null
+      },
+      "financials": {
+        "type_code": "I",
+        "type_label": "Remittance Information Only",
+        "total_payment_amount": "1261.03",
+        "credit": true,
+        "debit": false,
+        "payment_method_code": "ACH",
+        "payment_method_label": "Automated Clearing House (ACH)",
+        "payment_format_code": "CCP",
+        "payment_format_label": "Cash Concentration/Disbursement plus Addenda (CCD+) (ACH)",
+        "payment_date": "2016-02-03",
+        "payment_trace_number": "710618145",
+        "sender": {
+          "dfi_id_qualifier": "01",
+          "dfi_id_qualifier_label": "ABA Transit Routing Number Including Check Digits (9 digits)",
+          "dfi_id": "091000019",
+          "account_number": "1382069753",
+          "id": "1382069753",
+          "supplemental_code": ""
+        },
+        "receiver": {
+          "dfi_id_qualifier": "01",
+          "dfi_id_qualifier_label": "ABA Transit Routing Number Including Check Digits (9 digits)",
+          "dfi_id": "072000096",
+          "account_type": "Demand Deposit",
+          "account_number": "1852205283"
+        }
+      },
+      "payee": {
+        "name": "JENNIFER DESCHRYVER INC",
+        "npi": "1932382397",
+        "address": {
+          "street_line_1": null,
+          "street_line_2": null,
+          "city": "BLOOMFLD HLS",
+          "state": "MI",
+          "zip": "483013068"
+        },
+        "additional_ids": [
+          {
+            "type_code": "TJ",
+            "type_label": "Federal Taxpayer's Identification Number",
+            "value": "123123123"
+          }
+        ],
+        "adjustments": [],
+        "delivery_method": null
+      },
+      "patient": {
+        "first_name": "*****MIN",
+        "last_name": "*****LIN",
+        "middle_name": "J",
+        "id": "*******890"
+      },
+      "corrected_patient": {
+        "first_name": null,
+        "last_name": null,
+        "middle_name": null,
+        "id": null
+      },
+      "other_patient": {
+        "first_name": null,
+        "last_name": null,
+        "middle_name": null,
+        "id": null
+      },
+      "service_provider": null,
+      "claim": {
+        "control_number": "26160262372500710",
+        "received_date": "2016-04-15",
+        "expiration_date": null,
+        "filing_indicator_type": "12",
+        "filing_indicator_label": "Preferred Provider Organization (PPO)",
+        "place_of_service": "11",
+        "frequency": "1",
+        "responsibility_sequence": "primary",
+        "status": [
+          "processed"
+        ],
+        "drg_code": null,
+        "drg_quantity": null,
+        "amount": {
+          "billed": 435,
+          "paid": 33.7,
+          "patient_responsibility": 260,
+          "total_coverage": 298.68,
+          "prompt_payment_discount": null,
+          "per_day_limit": null,
+          "patient_paid": null,
+          "revised_interest": null,
+          "negative_ledger_balance": null,
+          "tax": null,
+          "total_claim_before_taxes": null,
+          "federal": {
+            "category_1": null,
+            "category_2": null,
+            "category_3": null,
+            "category_4": null,
+            "category_5": null
+          }
+        },
+        "adjustments": [],
+        "quantity": {
+          "actual": {
+            "covered": null,
+            "co_insured": null,
+            "life_time_reserve": null
+          },
+          "estimated": {
+            "life_time_reserve": null,
+            "non_covered": null
+          },
+          "not_replaced_blood_unit": null,
+          "outlier_days": null,
+          "prescription": null,
+          "visits": null,
+          "federal": {
+            "category_1": null,
+            "category_2": null,
+            "category_3": null,
+            "category_4": null,
+            "category_5": null
+          }
+        },
+        "additional_ids": [],
+        "rendering_provider_ids": [],
+        "moa_codes": [],
+        "allowed_amount": 298.68,
+        "contacts": [],
+        "service_lines": [
+          {
+            "procedure_qualifier": "HC<90834",
+            "procedure_code": null,
+            "procedure_modifiers": [],
+            "revenue_code": "",
+            "service_start": "2016-04-15",
+            "service_end": "2016-04-15",
+            "amount": {
+              "billed": 145,
+              "paid": 0,
+              "total_coverage": 99.56,
+              "deduction": null,
+              "tax": null,
+              "total_claim_before_taxes": null,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "quantity": {
+              "billed": 0,
+              "paid": 1,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "additional_ids": [],
+            "rendering_provider_ids": [],
+            "allowed_amount": 99.56,
+            "remark_codes": [],
+            "provider_control_number": "123123123",
+            "healthcare_policy": [],
+            "adjustments": [
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "1",
+                "reason_label": "Deductible Amount",
+                "amount": 79.56,
+                "quantity": 0
+              },
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "3",
+                "reason_label": "Co-payment Amount",
+                "amount": 20,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "45",
+                "reason_label": "Charge exceeds fee schedule/maximum allowable or contracted/legislated fee arrangement. (Use only with Group Codes PR or CO depending upon liability)",
+                "amount": 45.44,
+                "quantity": 0
+              }
+            ]
+          },
+          {
+            "procedure_qualifier": "HC<90834",
+            "procedure_code": null,
+            "procedure_modifiers": [],
+            "revenue_code": "",
+            "service_start": "2016-04-15",
+            "service_end": "2016-04-15",
+            "amount": {
+              "billed": 145,
+              "paid": 0,
+              "total_coverage": 99.56,
+              "deduction": null,
+              "tax": null,
+              "total_claim_before_taxes": null,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "quantity": {
+              "billed": 0,
+              "paid": 1,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "additional_ids": [],
+            "rendering_provider_ids": [],
+            "allowed_amount": 99.56,
+            "remark_codes": [],
+            "provider_control_number": "123123123",
+            "healthcare_policy": [],
+            "adjustments": [
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "1",
+                "reason_label": "Deductible Amount",
+                "amount": 79.56,
+                "quantity": 0
+              },
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "3",
+                "reason_label": "Co-payment Amount",
+                "amount": 20,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "45",
+                "reason_label": "Charge exceeds fee schedule/maximum allowable or contracted/legislated fee arrangement. (Use only with Group Codes PR or CO depending upon liability)",
+                "amount": 45.44,
+                "quantity": 0
+              }
+            ]
+          },
+          {
+            "procedure_qualifier": "HC<90834",
+            "procedure_code": null,
+            "procedure_modifiers": [],
+            "revenue_code": "",
+            "service_start": "2016-04-15",
+            "service_end": "2016-04-15",
+            "amount": {
+              "billed": 145,
+              "paid": 33.7,
+              "total_coverage": 99.56,
+              "deduction": null,
+              "tax": null,
+              "total_claim_before_taxes": null,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "quantity": {
+              "billed": 0,
+              "paid": 1,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "additional_ids": [],
+            "rendering_provider_ids": [],
+            "allowed_amount": 99.56,
+            "remark_codes": [],
+            "provider_control_number": "123123123",
+            "healthcare_policy": [],
+            "adjustments": [
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "1",
+                "reason_label": "Deductible Amount",
+                "amount": 40.88,
+                "quantity": 0
+              },
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "3",
+                "reason_label": "Co-payment Amount",
+                "amount": 20,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "144",
+                "reason_label": "Incentive adjustment, e.g. preferred product/service.",
+                "amount": 4.98,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "45",
+                "reason_label": "Charge exceeds fee schedule/maximum allowable or contracted/legislated fee arrangement. (Use only with Group Codes PR or CO depending upon liability)",
+                "amount": 45.44,
+                "quantity": 0
+              }
+            ]
+          }
+        ]
+      },
+      "reference_id": "8K9YM6SEXKLB5X"
+    },
+    {
+      "effective_date": "2016-04-15",
+      "payer": {
+        "name": "BCBSM",
+        "id": "ELIG_SNDBX",
+        "address": {
+          "street_line_1": "600 E LAFAYETTE",
+          "street_line_2": null,
+          "city": "DETROIT",
+          "state": "MI",
+          "zip": "482260000"
+        },
+        "contacts": [
+          {
+            "department_code": "CX",
+            "department_label": "Payers Claim Office. Location responsible for paying bills related to medical care received",
+            "name": "EDI HELPDESK",
+            "details": [
+              {
+                "type_code": "TE",
+                "type_label": "Telephone",
+                "value": "8005420945"
+              },
+              {
+                "type_code": "FX",
+                "type_label": "Facsimile",
+                "value": "2484862453"
+              }
+            ]
+          },
+          {
+            "department_code": "BL",
+            "department_label": "Technical Department",
+            "name": "EDI HELPDESK",
+            "details": [
+              {
+                "type_code": "TE",
+                "type_label": "Telephone",
+                "value": "8005420945"
+              },
+              {
+                "type_code": "FX",
+                "type_label": "Facsimile",
+                "value": "2484862453"
+              },
+              {
+                "type_code": "EM",
+                "type_label": "Electronic Mail",
+                "value": "EDI@BCBSM.COM"
+              }
+            ]
+          }
+        ],
+        "crossover_payer": null,
+        "corrected_priority_payer": null
+      },
+      "financials": {
+        "type_code": "I",
+        "type_label": "Remittance Information Only",
+        "total_payment_amount": "1261.03",
+        "credit": true,
+        "debit": false,
+        "payment_method_code": "ACH",
+        "payment_method_label": "Automated Clearing House (ACH)",
+        "payment_format_code": "CCP",
+        "payment_format_label": "Cash Concentration/Disbursement plus Addenda (CCD+) (ACH)",
+        "payment_date": "2016-02-03",
+        "payment_trace_number": "710618145",
+        "sender": {
+          "dfi_id_qualifier": "01",
+          "dfi_id_qualifier_label": "ABA Transit Routing Number Including Check Digits (9 digits)",
+          "dfi_id": "091000019",
+          "account_number": "1382069753",
+          "id": "1382069753",
+          "supplemental_code": ""
+        },
+        "receiver": {
+          "dfi_id_qualifier": "01",
+          "dfi_id_qualifier_label": "ABA Transit Routing Number Including Check Digits (9 digits)",
+          "dfi_id": "072000096",
+          "account_type": "Demand Deposit",
+          "account_number": "1852205283"
+        }
+      },
+      "payee": {
+        "name": "JENNIFER DESCHRYVER INC",
+        "npi": "1932382397",
+        "address": {
+          "street_line_1": null,
+          "street_line_2": null,
+          "city": "BLOOMFLD HLS",
+          "state": "MI",
+          "zip": "483013068"
+        },
+        "additional_ids": [
+          {
+            "type_code": "TJ",
+            "type_label": "Federal Taxpayer's Identification Number",
+            "value": "123123123"
+          }
+        ],
+        "adjustments": [],
+        "delivery_method": null
+      },
+      "patient": {
+        "first_name": "*****MIN",
+        "last_name": "*****LIN",
+        "middle_name": "J",
+        "id": "*******890"
+      },
+      "corrected_patient": {
+        "first_name": null,
+        "last_name": null,
+        "middle_name": null,
+        "id": null
+      },
+      "other_patient": {
+        "first_name": null,
+        "last_name": null,
+        "middle_name": null,
+        "id": null
+      },
+      "service_provider": null,
+      "claim": {
+        "control_number": "26160262372500710",
+        "received_date": "2016-04-15",
+        "expiration_date": null,
+        "filing_indicator_type": "12",
+        "filing_indicator_label": "Preferred Provider Organization (PPO)",
+        "place_of_service": "11",
+        "frequency": "1",
+        "responsibility_sequence": "primary",
+        "status": [
+          "processed"
+        ],
+        "drg_code": null,
+        "drg_quantity": null,
+        "amount": {
+          "billed": 435,
+          "paid": 33.7,
+          "patient_responsibility": 260,
+          "total_coverage": 298.68,
+          "prompt_payment_discount": null,
+          "per_day_limit": null,
+          "patient_paid": null,
+          "revised_interest": null,
+          "negative_ledger_balance": null,
+          "tax": null,
+          "total_claim_before_taxes": null,
+          "federal": {
+            "category_1": null,
+            "category_2": null,
+            "category_3": null,
+            "category_4": null,
+            "category_5": null
+          }
+        },
+        "adjustments": [],
+        "quantity": {
+          "actual": {
+            "covered": null,
+            "co_insured": null,
+            "life_time_reserve": null
+          },
+          "estimated": {
+            "life_time_reserve": null,
+            "non_covered": null
+          },
+          "not_replaced_blood_unit": null,
+          "outlier_days": null,
+          "prescription": null,
+          "visits": null,
+          "federal": {
+            "category_1": null,
+            "category_2": null,
+            "category_3": null,
+            "category_4": null,
+            "category_5": null
+          }
+        },
+        "additional_ids": [],
+        "rendering_provider_ids": [],
+        "moa_codes": [],
+        "allowed_amount": 298.68,
+        "contacts": [],
+        "service_lines": [
+          {
+            "procedure_qualifier": "HC<90834",
+            "procedure_code": null,
+            "procedure_modifiers": [],
+            "revenue_code": "",
+            "service_start": "2016-04-15",
+            "service_end": "2016-04-15",
+            "amount": {
+              "billed": 145,
+              "paid": 0,
+              "total_coverage": 99.56,
+              "deduction": null,
+              "tax": null,
+              "total_claim_before_taxes": null,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "quantity": {
+              "billed": 0,
+              "paid": 1,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "additional_ids": [],
+            "rendering_provider_ids": [],
+            "allowed_amount": 99.56,
+            "remark_codes": [],
+            "provider_control_number": "123123123",
+            "healthcare_policy": [],
+            "adjustments": [
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "1",
+                "reason_label": "Deductible Amount",
+                "amount": 79.56,
+                "quantity": 0
+              },
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "3",
+                "reason_label": "Co-payment Amount",
+                "amount": 20,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "45",
+                "reason_label": "Charge exceeds fee schedule/maximum allowable or contracted/legislated fee arrangement. (Use only with Group Codes PR or CO depending upon liability)",
+                "amount": 45.44,
+                "quantity": 0
+              }
+            ]
+          },
+          {
+            "procedure_qualifier": "HC<90834",
+            "procedure_code": null,
+            "procedure_modifiers": [],
+            "revenue_code": "",
+            "service_start": "2016-04-15",
+            "service_end": "2016-04-15",
+            "amount": {
+              "billed": 145,
+              "paid": 0,
+              "total_coverage": 99.56,
+              "deduction": null,
+              "tax": null,
+              "total_claim_before_taxes": null,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "quantity": {
+              "billed": 0,
+              "paid": 1,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "additional_ids": [],
+            "rendering_provider_ids": [],
+            "allowed_amount": 99.56,
+            "remark_codes": [],
+            "provider_control_number": "123123123",
+            "healthcare_policy": [],
+            "adjustments": [
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "1",
+                "reason_label": "Deductible Amount",
+                "amount": 79.56,
+                "quantity": 0
+              },
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "3",
+                "reason_label": "Co-payment Amount",
+                "amount": 20,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "45",
+                "reason_label": "Charge exceeds fee schedule/maximum allowable or contracted/legislated fee arrangement. (Use only with Group Codes PR or CO depending upon liability)",
+                "amount": 45.44,
+                "quantity": 0
+              }
+            ]
+          },
+          {
+            "procedure_qualifier": "HC<90834",
+            "procedure_code": null,
+            "procedure_modifiers": [],
+            "revenue_code": "",
+            "service_start": "2016-04-15",
+            "service_end": "2016-04-15",
+            "amount": {
+              "billed": 145,
+              "paid": 33.7,
+              "total_coverage": 99.56,
+              "deduction": null,
+              "tax": null,
+              "total_claim_before_taxes": null,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "quantity": {
+              "billed": 0,
+              "paid": 1,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "additional_ids": [],
+            "rendering_provider_ids": [],
+            "allowed_amount": 99.56,
+            "remark_codes": [],
+            "provider_control_number": "123123123",
+            "healthcare_policy": [],
+            "adjustments": [
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "1",
+                "reason_label": "Deductible Amount",
+                "amount": 40.88,
+                "quantity": 0
+              },
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "3",
+                "reason_label": "Co-payment Amount",
+                "amount": 20,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "144",
+                "reason_label": "Incentive adjustment, e.g. preferred product/service.",
+                "amount": 4.98,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "45",
+                "reason_label": "Charge exceeds fee schedule/maximum allowable or contracted/legislated fee arrangement. (Use only with Group Codes PR or CO depending upon liability)",
+                "amount": 45.44,
+                "quantity": 0
+              }
+            ]
+          }
+        ]
+      },
+      "reference_id": "8K9YM6SEXKLB5X"
+    },
+    {
+      "effective_date": "2016-04-15",
+      "payer": {
+        "name": "BCBSM",
+        "id": "ELIG_SNDBX",
+        "address": {
+          "street_line_1": "600 E LAFAYETTE",
+          "street_line_2": null,
+          "city": "DETROIT",
+          "state": "MI",
+          "zip": "482260000"
+        },
+        "contacts": [
+          {
+            "department_code": "CX",
+            "department_label": "Payers Claim Office. Location responsible for paying bills related to medical care received",
+            "name": "EDI HELPDESK",
+            "details": [
+              {
+                "type_code": "TE",
+                "type_label": "Telephone",
+                "value": "8005420945"
+              },
+              {
+                "type_code": "FX",
+                "type_label": "Facsimile",
+                "value": "2484862453"
+              }
+            ]
+          },
+          {
+            "department_code": "BL",
+            "department_label": "Technical Department",
+            "name": "EDI HELPDESK",
+            "details": [
+              {
+                "type_code": "TE",
+                "type_label": "Telephone",
+                "value": "8005420945"
+              },
+              {
+                "type_code": "FX",
+                "type_label": "Facsimile",
+                "value": "2484862453"
+              },
+              {
+                "type_code": "EM",
+                "type_label": "Electronic Mail",
+                "value": "EDI@BCBSM.COM"
+              }
+            ]
+          }
+        ],
+        "crossover_payer": null,
+        "corrected_priority_payer": null
+      },
+      "financials": {
+        "type_code": "I",
+        "type_label": "Remittance Information Only",
+        "total_payment_amount": "1261.03",
+        "credit": true,
+        "debit": false,
+        "payment_method_code": "ACH",
+        "payment_method_label": "Automated Clearing House (ACH)",
+        "payment_format_code": "CCP",
+        "payment_format_label": "Cash Concentration/Disbursement plus Addenda (CCD+) (ACH)",
+        "payment_date": "2016-02-03",
+        "payment_trace_number": "710618145",
+        "sender": {
+          "dfi_id_qualifier": "01",
+          "dfi_id_qualifier_label": "ABA Transit Routing Number Including Check Digits (9 digits)",
+          "dfi_id": "091000019",
+          "account_number": "1382069753",
+          "id": "1382069753",
+          "supplemental_code": ""
+        },
+        "receiver": {
+          "dfi_id_qualifier": "01",
+          "dfi_id_qualifier_label": "ABA Transit Routing Number Including Check Digits (9 digits)",
+          "dfi_id": "072000096",
+          "account_type": "Demand Deposit",
+          "account_number": "1852205283"
+        }
+      },
+      "payee": {
+        "name": "JENNIFER DESCHRYVER INC",
+        "npi": "1932382397",
+        "address": {
+          "street_line_1": null,
+          "street_line_2": null,
+          "city": "BLOOMFLD HLS",
+          "state": "MI",
+          "zip": "483013068"
+        },
+        "additional_ids": [
+          {
+            "type_code": "TJ",
+            "type_label": "Federal Taxpayer's Identification Number",
+            "value": "123123123"
+          }
+        ],
+        "adjustments": [],
+        "delivery_method": null
+      },
+      "patient": {
+        "first_name": "*****MIN",
+        "last_name": "*****LIN",
+        "middle_name": "J",
+        "id": "*******890"
+      },
+      "corrected_patient": {
+        "first_name": null,
+        "last_name": null,
+        "middle_name": null,
+        "id": null
+      },
+      "other_patient": {
+        "first_name": null,
+        "last_name": null,
+        "middle_name": null,
+        "id": null
+      },
+      "service_provider": null,
+      "claim": {
+        "control_number": "26160262372500710",
+        "received_date": "2016-04-15",
+        "expiration_date": null,
+        "filing_indicator_type": "12",
+        "filing_indicator_label": "Preferred Provider Organization (PPO)",
+        "place_of_service": "11",
+        "frequency": "1",
+        "responsibility_sequence": "primary",
+        "status": [
+          "processed"
+        ],
+        "drg_code": null,
+        "drg_quantity": null,
+        "amount": {
+          "billed": 435,
+          "paid": 33.7,
+          "patient_responsibility": 260,
+          "total_coverage": 298.68,
+          "prompt_payment_discount": null,
+          "per_day_limit": null,
+          "patient_paid": null,
+          "revised_interest": null,
+          "negative_ledger_balance": null,
+          "tax": null,
+          "total_claim_before_taxes": null,
+          "federal": {
+            "category_1": null,
+            "category_2": null,
+            "category_3": null,
+            "category_4": null,
+            "category_5": null
+          }
+        },
+        "adjustments": [],
+        "quantity": {
+          "actual": {
+            "covered": null,
+            "co_insured": null,
+            "life_time_reserve": null
+          },
+          "estimated": {
+            "life_time_reserve": null,
+            "non_covered": null
+          },
+          "not_replaced_blood_unit": null,
+          "outlier_days": null,
+          "prescription": null,
+          "visits": null,
+          "federal": {
+            "category_1": null,
+            "category_2": null,
+            "category_3": null,
+            "category_4": null,
+            "category_5": null
+          }
+        },
+        "additional_ids": [],
+        "rendering_provider_ids": [],
+        "moa_codes": [],
+        "allowed_amount": 298.68,
+        "contacts": [],
+        "service_lines": [
+          {
+            "procedure_qualifier": "HC<90834",
+            "procedure_code": null,
+            "procedure_modifiers": [],
+            "revenue_code": "",
+            "service_start": "2016-04-15",
+            "service_end": "2016-04-15",
+            "amount": {
+              "billed": 145,
+              "paid": 0,
+              "total_coverage": 99.56,
+              "deduction": null,
+              "tax": null,
+              "total_claim_before_taxes": null,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "quantity": {
+              "billed": 0,
+              "paid": 1,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "additional_ids": [],
+            "rendering_provider_ids": [],
+            "allowed_amount": 99.56,
+            "remark_codes": [],
+            "provider_control_number": "123123123",
+            "healthcare_policy": [],
+            "adjustments": [
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "1",
+                "reason_label": "Deductible Amount",
+                "amount": 79.56,
+                "quantity": 0
+              },
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "3",
+                "reason_label": "Co-payment Amount",
+                "amount": 20,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "45",
+                "reason_label": "Charge exceeds fee schedule/maximum allowable or contracted/legislated fee arrangement. (Use only with Group Codes PR or CO depending upon liability)",
+                "amount": 45.44,
+                "quantity": 0
+              }
+            ]
+          },
+          {
+            "procedure_qualifier": "HC<90834",
+            "procedure_code": null,
+            "procedure_modifiers": [],
+            "revenue_code": "",
+            "service_start": "2016-04-15",
+            "service_end": "2016-04-15",
+            "amount": {
+              "billed": 145,
+              "paid": 0,
+              "total_coverage": 99.56,
+              "deduction": null,
+              "tax": null,
+              "total_claim_before_taxes": null,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "quantity": {
+              "billed": 0,
+              "paid": 1,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "additional_ids": [],
+            "rendering_provider_ids": [],
+            "allowed_amount": 99.56,
+            "remark_codes": [],
+            "provider_control_number": "123123123",
+            "healthcare_policy": [],
+            "adjustments": [
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "1",
+                "reason_label": "Deductible Amount",
+                "amount": 79.56,
+                "quantity": 0
+              },
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "3",
+                "reason_label": "Co-payment Amount",
+                "amount": 20,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "45",
+                "reason_label": "Charge exceeds fee schedule/maximum allowable or contracted/legislated fee arrangement. (Use only with Group Codes PR or CO depending upon liability)",
+                "amount": 45.44,
+                "quantity": 0
+              }
+            ]
+          },
+          {
+            "procedure_qualifier": "HC<90834",
+            "procedure_code": null,
+            "procedure_modifiers": [],
+            "revenue_code": "",
+            "service_start": "2016-04-15",
+            "service_end": "2016-04-15",
+            "amount": {
+              "billed": 145,
+              "paid": 33.7,
+              "total_coverage": 99.56,
+              "deduction": null,
+              "tax": null,
+              "total_claim_before_taxes": null,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "quantity": {
+              "billed": 0,
+              "paid": 1,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "additional_ids": [],
+            "rendering_provider_ids": [],
+            "allowed_amount": 99.56,
+            "remark_codes": [],
+            "provider_control_number": "123123123",
+            "healthcare_policy": [],
+            "adjustments": [
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "1",
+                "reason_label": "Deductible Amount",
+                "amount": 40.88,
+                "quantity": 0
+              },
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "3",
+                "reason_label": "Co-payment Amount",
+                "amount": 20,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "144",
+                "reason_label": "Incentive adjustment, e.g. preferred product/service.",
+                "amount": 4.98,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "45",
+                "reason_label": "Charge exceeds fee schedule/maximum allowable or contracted/legislated fee arrangement. (Use only with Group Codes PR or CO depending upon liability)",
+                "amount": 45.44,
+                "quantity": 0
+              }
+            ]
+          }
+        ]
+      },
+      "reference_id": "8K9YM79BVDDYEO"
+    },
+    {
+      "effective_date": "2016-04-15",
+      "payer": {
+        "name": "BCBSM",
+        "id": "ELIG_SNDBX",
+        "address": {
+          "street_line_1": "600 E LAFAYETTE",
+          "street_line_2": null,
+          "city": "DETROIT",
+          "state": "MI",
+          "zip": "482260000"
+        },
+        "contacts": [
+          {
+            "department_code": "CX",
+            "department_label": "Payers Claim Office. Location responsible for paying bills related to medical care received",
+            "name": "EDI HELPDESK",
+            "details": [
+              {
+                "type_code": "TE",
+                "type_label": "Telephone",
+                "value": "8005420945"
+              },
+              {
+                "type_code": "FX",
+                "type_label": "Facsimile",
+                "value": "2484862453"
+              }
+            ]
+          },
+          {
+            "department_code": "BL",
+            "department_label": "Technical Department",
+            "name": "EDI HELPDESK",
+            "details": [
+              {
+                "type_code": "TE",
+                "type_label": "Telephone",
+                "value": "8005420945"
+              },
+              {
+                "type_code": "FX",
+                "type_label": "Facsimile",
+                "value": "2484862453"
+              },
+              {
+                "type_code": "EM",
+                "type_label": "Electronic Mail",
+                "value": "EDI@BCBSM.COM"
+              }
+            ]
+          }
+        ],
+        "crossover_payer": null,
+        "corrected_priority_payer": null
+      },
+      "financials": {
+        "type_code": "I",
+        "type_label": "Remittance Information Only",
+        "total_payment_amount": "1261.03",
+        "credit": true,
+        "debit": false,
+        "payment_method_code": "ACH",
+        "payment_method_label": "Automated Clearing House (ACH)",
+        "payment_format_code": "CCP",
+        "payment_format_label": "Cash Concentration/Disbursement plus Addenda (CCD+) (ACH)",
+        "payment_date": "2016-02-03",
+        "payment_trace_number": "710618145",
+        "sender": {
+          "dfi_id_qualifier": "01",
+          "dfi_id_qualifier_label": "ABA Transit Routing Number Including Check Digits (9 digits)",
+          "dfi_id": "091000019",
+          "account_number": "1382069753",
+          "id": "1382069753",
+          "supplemental_code": ""
+        },
+        "receiver": {
+          "dfi_id_qualifier": "01",
+          "dfi_id_qualifier_label": "ABA Transit Routing Number Including Check Digits (9 digits)",
+          "dfi_id": "072000096",
+          "account_type": "Demand Deposit",
+          "account_number": "1852205283"
+        }
+      },
+      "payee": {
+        "name": "JENNIFER DESCHRYVER INC",
+        "npi": "1932382397",
+        "address": {
+          "street_line_1": null,
+          "street_line_2": null,
+          "city": "BLOOMFLD HLS",
+          "state": "MI",
+          "zip": "483013068"
+        },
+        "additional_ids": [
+          {
+            "type_code": "TJ",
+            "type_label": "Federal Taxpayer's Identification Number",
+            "value": "123123123"
+          }
+        ],
+        "adjustments": [],
+        "delivery_method": null
+      },
+      "patient": {
+        "first_name": "*****MIN",
+        "last_name": "*****LIN",
+        "middle_name": "J",
+        "id": "*******890"
+      },
+      "corrected_patient": {
+        "first_name": null,
+        "last_name": null,
+        "middle_name": null,
+        "id": null
+      },
+      "other_patient": {
+        "first_name": null,
+        "last_name": null,
+        "middle_name": null,
+        "id": null
+      },
+      "service_provider": null,
+      "claim": {
+        "control_number": "26160262372500710",
+        "received_date": "2016-04-15",
+        "expiration_date": null,
+        "filing_indicator_type": "12",
+        "filing_indicator_label": "Preferred Provider Organization (PPO)",
+        "place_of_service": "11",
+        "frequency": "1",
+        "responsibility_sequence": "primary",
+        "status": [
+          "processed"
+        ],
+        "drg_code": null,
+        "drg_quantity": null,
+        "amount": {
+          "billed": 435,
+          "paid": 33.7,
+          "patient_responsibility": 260,
+          "total_coverage": 298.68,
+          "prompt_payment_discount": null,
+          "per_day_limit": null,
+          "patient_paid": null,
+          "revised_interest": null,
+          "negative_ledger_balance": null,
+          "tax": null,
+          "total_claim_before_taxes": null,
+          "federal": {
+            "category_1": null,
+            "category_2": null,
+            "category_3": null,
+            "category_4": null,
+            "category_5": null
+          }
+        },
+        "adjustments": [],
+        "quantity": {
+          "actual": {
+            "covered": null,
+            "co_insured": null,
+            "life_time_reserve": null
+          },
+          "estimated": {
+            "life_time_reserve": null,
+            "non_covered": null
+          },
+          "not_replaced_blood_unit": null,
+          "outlier_days": null,
+          "prescription": null,
+          "visits": null,
+          "federal": {
+            "category_1": null,
+            "category_2": null,
+            "category_3": null,
+            "category_4": null,
+            "category_5": null
+          }
+        },
+        "additional_ids": [],
+        "rendering_provider_ids": [],
+        "moa_codes": [],
+        "allowed_amount": 298.68,
+        "contacts": [],
+        "service_lines": [
+          {
+            "procedure_qualifier": "HC<90834",
+            "procedure_code": null,
+            "procedure_modifiers": [],
+            "revenue_code": "",
+            "service_start": "2016-04-15",
+            "service_end": "2016-04-15",
+            "amount": {
+              "billed": 145,
+              "paid": 0,
+              "total_coverage": 99.56,
+              "deduction": null,
+              "tax": null,
+              "total_claim_before_taxes": null,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "quantity": {
+              "billed": 0,
+              "paid": 1,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "additional_ids": [],
+            "rendering_provider_ids": [],
+            "allowed_amount": 99.56,
+            "remark_codes": [],
+            "provider_control_number": "123123123",
+            "healthcare_policy": [],
+            "adjustments": [
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "1",
+                "reason_label": "Deductible Amount",
+                "amount": 79.56,
+                "quantity": 0
+              },
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "3",
+                "reason_label": "Co-payment Amount",
+                "amount": 20,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "45",
+                "reason_label": "Charge exceeds fee schedule/maximum allowable or contracted/legislated fee arrangement. (Use only with Group Codes PR or CO depending upon liability)",
+                "amount": 45.44,
+                "quantity": 0
+              }
+            ]
+          },
+          {
+            "procedure_qualifier": "HC<90834",
+            "procedure_code": null,
+            "procedure_modifiers": [],
+            "revenue_code": "",
+            "service_start": "2016-04-15",
+            "service_end": "2016-04-15",
+            "amount": {
+              "billed": 145,
+              "paid": 0,
+              "total_coverage": 99.56,
+              "deduction": null,
+              "tax": null,
+              "total_claim_before_taxes": null,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "quantity": {
+              "billed": 0,
+              "paid": 1,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "additional_ids": [],
+            "rendering_provider_ids": [],
+            "allowed_amount": 99.56,
+            "remark_codes": [],
+            "provider_control_number": "123123123",
+            "healthcare_policy": [],
+            "adjustments": [
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "1",
+                "reason_label": "Deductible Amount",
+                "amount": 79.56,
+                "quantity": 0
+              },
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "3",
+                "reason_label": "Co-payment Amount",
+                "amount": 20,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "45",
+                "reason_label": "Charge exceeds fee schedule/maximum allowable or contracted/legislated fee arrangement. (Use only with Group Codes PR or CO depending upon liability)",
+                "amount": 45.44,
+                "quantity": 0
+              }
+            ]
+          },
+          {
+            "procedure_qualifier": "HC<90834",
+            "procedure_code": null,
+            "procedure_modifiers": [],
+            "revenue_code": "",
+            "service_start": "2016-04-15",
+            "service_end": "2016-04-15",
+            "amount": {
+              "billed": 145,
+              "paid": 33.7,
+              "total_coverage": 99.56,
+              "deduction": null,
+              "tax": null,
+              "total_claim_before_taxes": null,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "quantity": {
+              "billed": 0,
+              "paid": 1,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "additional_ids": [],
+            "rendering_provider_ids": [],
+            "allowed_amount": 99.56,
+            "remark_codes": [],
+            "provider_control_number": "123123123",
+            "healthcare_policy": [],
+            "adjustments": [
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "1",
+                "reason_label": "Deductible Amount",
+                "amount": 40.88,
+                "quantity": 0
+              },
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "3",
+                "reason_label": "Co-payment Amount",
+                "amount": 20,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "144",
+                "reason_label": "Incentive adjustment, e.g. preferred product/service.",
+                "amount": 4.98,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "45",
+                "reason_label": "Charge exceeds fee schedule/maximum allowable or contracted/legislated fee arrangement. (Use only with Group Codes PR or CO depending upon liability)",
+                "amount": 45.44,
+                "quantity": 0
+              }
+            ]
+          }
+        ]
+      },
+      "reference_id": "32Z9JSU0QLSGZ"
+    },
+    {
+      "effective_date": "2016-04-15",
+      "payer": {
+        "name": "BCBSM",
+        "id": "ELIG_SNDBX",
+        "address": {
+          "street_line_1": "600 E LAFAYETTE",
+          "street_line_2": null,
+          "city": "DETROIT",
+          "state": "MI",
+          "zip": "482260000"
+        },
+        "contacts": [
+          {
+            "department_code": "CX",
+            "department_label": "Payers Claim Office. Location responsible for paying bills related to medical care received",
+            "name": "EDI HELPDESK",
+            "details": [
+              {
+                "type_code": "TE",
+                "type_label": "Telephone",
+                "value": "8005420945"
+              },
+              {
+                "type_code": "FX",
+                "type_label": "Facsimile",
+                "value": "2484862453"
+              }
+            ]
+          },
+          {
+            "department_code": "BL",
+            "department_label": "Technical Department",
+            "name": "EDI HELPDESK",
+            "details": [
+              {
+                "type_code": "TE",
+                "type_label": "Telephone",
+                "value": "8005420945"
+              },
+              {
+                "type_code": "FX",
+                "type_label": "Facsimile",
+                "value": "2484862453"
+              },
+              {
+                "type_code": "EM",
+                "type_label": "Electronic Mail",
+                "value": "EDI@BCBSM.COM"
+              }
+            ]
+          }
+        ],
+        "crossover_payer": null,
+        "corrected_priority_payer": null
+      },
+      "financials": {
+        "type_code": "I",
+        "type_label": "Remittance Information Only",
+        "total_payment_amount": "1261.03",
+        "credit": true,
+        "debit": false,
+        "payment_method_code": "ACH",
+        "payment_method_label": "Automated Clearing House (ACH)",
+        "payment_format_code": "CCP",
+        "payment_format_label": "Cash Concentration/Disbursement plus Addenda (CCD+) (ACH)",
+        "payment_date": "2016-02-03",
+        "payment_trace_number": "710618145",
+        "sender": {
+          "dfi_id_qualifier": "01",
+          "dfi_id_qualifier_label": "ABA Transit Routing Number Including Check Digits (9 digits)",
+          "dfi_id": "091000019",
+          "account_number": "1382069753",
+          "id": "1382069753",
+          "supplemental_code": ""
+        },
+        "receiver": {
+          "dfi_id_qualifier": "01",
+          "dfi_id_qualifier_label": "ABA Transit Routing Number Including Check Digits (9 digits)",
+          "dfi_id": "072000096",
+          "account_type": "Demand Deposit",
+          "account_number": "1852205283"
+        }
+      },
+      "payee": {
+        "name": "JENNIFER DESCHRYVER INC",
+        "npi": "1932382397",
+        "address": {
+          "street_line_1": null,
+          "street_line_2": null,
+          "city": "BLOOMFLD HLS",
+          "state": "MI",
+          "zip": "483013068"
+        },
+        "additional_ids": [
+          {
+            "type_code": "TJ",
+            "type_label": "Federal Taxpayer's Identification Number",
+            "value": "123123123"
+          }
+        ],
+        "adjustments": [],
+        "delivery_method": null
+      },
+      "patient": {
+        "first_name": "*****MIN",
+        "last_name": "*****LIN",
+        "middle_name": "J",
+        "id": "*******890"
+      },
+      "corrected_patient": {
+        "first_name": null,
+        "last_name": null,
+        "middle_name": null,
+        "id": null
+      },
+      "other_patient": {
+        "first_name": null,
+        "last_name": null,
+        "middle_name": null,
+        "id": null
+      },
+      "service_provider": null,
+      "claim": {
+        "control_number": "26160262372500710",
+        "received_date": "2016-04-15",
+        "expiration_date": null,
+        "filing_indicator_type": "12",
+        "filing_indicator_label": "Preferred Provider Organization (PPO)",
+        "place_of_service": "11",
+        "frequency": "1",
+        "responsibility_sequence": "primary",
+        "status": [
+          "processed"
+        ],
+        "drg_code": null,
+        "drg_quantity": null,
+        "amount": {
+          "billed": 435,
+          "paid": 33.7,
+          "patient_responsibility": 260,
+          "total_coverage": 298.68,
+          "prompt_payment_discount": null,
+          "per_day_limit": null,
+          "patient_paid": null,
+          "revised_interest": null,
+          "negative_ledger_balance": null,
+          "tax": null,
+          "total_claim_before_taxes": null,
+          "federal": {
+            "category_1": null,
+            "category_2": null,
+            "category_3": null,
+            "category_4": null,
+            "category_5": null
+          }
+        },
+        "adjustments": [],
+        "quantity": {
+          "actual": {
+            "covered": null,
+            "co_insured": null,
+            "life_time_reserve": null
+          },
+          "estimated": {
+            "life_time_reserve": null,
+            "non_covered": null
+          },
+          "not_replaced_blood_unit": null,
+          "outlier_days": null,
+          "prescription": null,
+          "visits": null,
+          "federal": {
+            "category_1": null,
+            "category_2": null,
+            "category_3": null,
+            "category_4": null,
+            "category_5": null
+          }
+        },
+        "additional_ids": [],
+        "rendering_provider_ids": [],
+        "moa_codes": [],
+        "allowed_amount": 298.68,
+        "contacts": [],
+        "service_lines": [
+          {
+            "procedure_qualifier": "HC<90834",
+            "procedure_code": null,
+            "procedure_modifiers": [],
+            "revenue_code": "",
+            "service_start": "2016-04-15",
+            "service_end": "2016-04-15",
+            "amount": {
+              "billed": 145,
+              "paid": 0,
+              "total_coverage": 99.56,
+              "deduction": null,
+              "tax": null,
+              "total_claim_before_taxes": null,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "quantity": {
+              "billed": 0,
+              "paid": 1,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "additional_ids": [],
+            "rendering_provider_ids": [],
+            "allowed_amount": 99.56,
+            "remark_codes": [],
+            "provider_control_number": "123123123",
+            "healthcare_policy": [],
+            "adjustments": [
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "1",
+                "reason_label": "Deductible Amount",
+                "amount": 79.56,
+                "quantity": 0
+              },
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "3",
+                "reason_label": "Co-payment Amount",
+                "amount": 20,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "45",
+                "reason_label": "Charge exceeds fee schedule/maximum allowable or contracted/legislated fee arrangement. (Use only with Group Codes PR or CO depending upon liability)",
+                "amount": 45.44,
+                "quantity": 0
+              }
+            ]
+          },
+          {
+            "procedure_qualifier": "HC<90834",
+            "procedure_code": null,
+            "procedure_modifiers": [],
+            "revenue_code": "",
+            "service_start": "2016-04-15",
+            "service_end": "2016-04-15",
+            "amount": {
+              "billed": 145,
+              "paid": 0,
+              "total_coverage": 99.56,
+              "deduction": null,
+              "tax": null,
+              "total_claim_before_taxes": null,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "quantity": {
+              "billed": 0,
+              "paid": 1,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "additional_ids": [],
+            "rendering_provider_ids": [],
+            "allowed_amount": 99.56,
+            "remark_codes": [],
+            "provider_control_number": "123123123",
+            "healthcare_policy": [],
+            "adjustments": [
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "1",
+                "reason_label": "Deductible Amount",
+                "amount": 79.56,
+                "quantity": 0
+              },
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "3",
+                "reason_label": "Co-payment Amount",
+                "amount": 20,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "45",
+                "reason_label": "Charge exceeds fee schedule/maximum allowable or contracted/legislated fee arrangement. (Use only with Group Codes PR or CO depending upon liability)",
+                "amount": 45.44,
+                "quantity": 0
+              }
+            ]
+          },
+          {
+            "procedure_qualifier": "HC<90834",
+            "procedure_code": null,
+            "procedure_modifiers": [],
+            "revenue_code": "",
+            "service_start": "2016-04-15",
+            "service_end": "2016-04-15",
+            "amount": {
+              "billed": 145,
+              "paid": 33.7,
+              "total_coverage": 99.56,
+              "deduction": null,
+              "tax": null,
+              "total_claim_before_taxes": null,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "quantity": {
+              "billed": 0,
+              "paid": 1,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "additional_ids": [],
+            "rendering_provider_ids": [],
+            "allowed_amount": 99.56,
+            "remark_codes": [],
+            "provider_control_number": "123123123",
+            "healthcare_policy": [],
+            "adjustments": [
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "1",
+                "reason_label": "Deductible Amount",
+                "amount": 40.88,
+                "quantity": 0
+              },
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "3",
+                "reason_label": "Co-payment Amount",
+                "amount": 20,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "144",
+                "reason_label": "Incentive adjustment, e.g. preferred product/service.",
+                "amount": 4.98,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "45",
+                "reason_label": "Charge exceeds fee schedule/maximum allowable or contracted/legislated fee arrangement. (Use only with Group Codes PR or CO depending upon liability)",
+                "amount": 45.44,
+                "quantity": 0
+              }
+            ]
+          }
+        ]
+      },
+      "reference_id": "8K9YIYKF89K17B"
+    },
+    {
+      "effective_date": "2016-04-15",
+      "payer": {
+        "name": "BCBSM",
+        "id": "ELIG_SNDBX",
+        "address": {
+          "street_line_1": "600 E LAFAYETTE",
+          "street_line_2": null,
+          "city": "DETROIT",
+          "state": "MI",
+          "zip": "482260000"
+        },
+        "contacts": [
+          {
+            "department_code": "CX",
+            "department_label": "Payers Claim Office. Location responsible for paying bills related to medical care received",
+            "name": "EDI HELPDESK",
+            "details": [
+              {
+                "type_code": "TE",
+                "type_label": "Telephone",
+                "value": "8005420945"
+              },
+              {
+                "type_code": "FX",
+                "type_label": "Facsimile",
+                "value": "2484862453"
+              }
+            ]
+          },
+          {
+            "department_code": "BL",
+            "department_label": "Technical Department",
+            "name": "EDI HELPDESK",
+            "details": [
+              {
+                "type_code": "TE",
+                "type_label": "Telephone",
+                "value": "8005420945"
+              },
+              {
+                "type_code": "FX",
+                "type_label": "Facsimile",
+                "value": "2484862453"
+              },
+              {
+                "type_code": "EM",
+                "type_label": "Electronic Mail",
+                "value": "EDI@BCBSM.COM"
+              }
+            ]
+          }
+        ],
+        "crossover_payer": null,
+        "corrected_priority_payer": null
+      },
+      "financials": {
+        "type_code": "I",
+        "type_label": "Remittance Information Only",
+        "total_payment_amount": "1261.03",
+        "credit": true,
+        "debit": false,
+        "payment_method_code": "ACH",
+        "payment_method_label": "Automated Clearing House (ACH)",
+        "payment_format_code": "CCP",
+        "payment_format_label": "Cash Concentration/Disbursement plus Addenda (CCD+) (ACH)",
+        "payment_date": "2016-02-03",
+        "payment_trace_number": "710618145",
+        "sender": {
+          "dfi_id_qualifier": "01",
+          "dfi_id_qualifier_label": "ABA Transit Routing Number Including Check Digits (9 digits)",
+          "dfi_id": "091000019",
+          "account_number": "1382069753",
+          "id": "1382069753",
+          "supplemental_code": ""
+        },
+        "receiver": {
+          "dfi_id_qualifier": "01",
+          "dfi_id_qualifier_label": "ABA Transit Routing Number Including Check Digits (9 digits)",
+          "dfi_id": "072000096",
+          "account_type": "Demand Deposit",
+          "account_number": "1852205283"
+        }
+      },
+      "payee": {
+        "name": "JENNIFER DESCHRYVER INC",
+        "npi": "1932382397",
+        "address": {
+          "street_line_1": null,
+          "street_line_2": null,
+          "city": "BLOOMFLD HLS",
+          "state": "MI",
+          "zip": "483013068"
+        },
+        "additional_ids": [
+          {
+            "type_code": "TJ",
+            "type_label": "Federal Taxpayer's Identification Number",
+            "value": "123123123"
+          }
+        ],
+        "adjustments": [],
+        "delivery_method": null
+      },
+      "patient": {
+        "first_name": "*****MIN",
+        "last_name": "*****LIN",
+        "middle_name": "J",
+        "id": "*******890"
+      },
+      "corrected_patient": {
+        "first_name": null,
+        "last_name": null,
+        "middle_name": null,
+        "id": null
+      },
+      "other_patient": {
+        "first_name": null,
+        "last_name": null,
+        "middle_name": null,
+        "id": null
+      },
+      "service_provider": null,
+      "claim": {
+        "control_number": "26160262372500710",
+        "received_date": "2016-04-15",
+        "expiration_date": null,
+        "filing_indicator_type": "12",
+        "filing_indicator_label": "Preferred Provider Organization (PPO)",
+        "place_of_service": "11",
+        "frequency": "1",
+        "responsibility_sequence": "primary",
+        "status": [
+          "processed"
+        ],
+        "drg_code": null,
+        "drg_quantity": null,
+        "amount": {
+          "billed": 435,
+          "paid": 33.7,
+          "patient_responsibility": 260,
+          "total_coverage": 298.68,
+          "prompt_payment_discount": null,
+          "per_day_limit": null,
+          "patient_paid": null,
+          "revised_interest": null,
+          "negative_ledger_balance": null,
+          "tax": null,
+          "total_claim_before_taxes": null,
+          "federal": {
+            "category_1": null,
+            "category_2": null,
+            "category_3": null,
+            "category_4": null,
+            "category_5": null
+          }
+        },
+        "adjustments": [],
+        "quantity": {
+          "actual": {
+            "covered": null,
+            "co_insured": null,
+            "life_time_reserve": null
+          },
+          "estimated": {
+            "life_time_reserve": null,
+            "non_covered": null
+          },
+          "not_replaced_blood_unit": null,
+          "outlier_days": null,
+          "prescription": null,
+          "visits": null,
+          "federal": {
+            "category_1": null,
+            "category_2": null,
+            "category_3": null,
+            "category_4": null,
+            "category_5": null
+          }
+        },
+        "additional_ids": [],
+        "rendering_provider_ids": [],
+        "moa_codes": [],
+        "allowed_amount": 298.68,
+        "contacts": [],
+        "service_lines": [
+          {
+            "procedure_qualifier": "HC<90834",
+            "procedure_code": null,
+            "procedure_modifiers": [],
+            "revenue_code": "",
+            "service_start": "2016-04-15",
+            "service_end": "2016-04-15",
+            "amount": {
+              "billed": 145,
+              "paid": 0,
+              "total_coverage": 99.56,
+              "deduction": null,
+              "tax": null,
+              "total_claim_before_taxes": null,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "quantity": {
+              "billed": 0,
+              "paid": 1,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "additional_ids": [],
+            "rendering_provider_ids": [],
+            "allowed_amount": 99.56,
+            "remark_codes": [],
+            "provider_control_number": "123123123",
+            "healthcare_policy": [],
+            "adjustments": [
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "1",
+                "reason_label": "Deductible Amount",
+                "amount": 79.56,
+                "quantity": 0
+              },
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "3",
+                "reason_label": "Co-payment Amount",
+                "amount": 20,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "45",
+                "reason_label": "Charge exceeds fee schedule/maximum allowable or contracted/legislated fee arrangement. (Use only with Group Codes PR or CO depending upon liability)",
+                "amount": 45.44,
+                "quantity": 0
+              }
+            ]
+          },
+          {
+            "procedure_qualifier": "HC<90834",
+            "procedure_code": null,
+            "procedure_modifiers": [],
+            "revenue_code": "",
+            "service_start": "2016-04-15",
+            "service_end": "2016-04-15",
+            "amount": {
+              "billed": 145,
+              "paid": 0,
+              "total_coverage": 99.56,
+              "deduction": null,
+              "tax": null,
+              "total_claim_before_taxes": null,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "quantity": {
+              "billed": 0,
+              "paid": 1,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "additional_ids": [],
+            "rendering_provider_ids": [],
+            "allowed_amount": 99.56,
+            "remark_codes": [],
+            "provider_control_number": "123123123",
+            "healthcare_policy": [],
+            "adjustments": [
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "1",
+                "reason_label": "Deductible Amount",
+                "amount": 79.56,
+                "quantity": 0
+              },
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "3",
+                "reason_label": "Co-payment Amount",
+                "amount": 20,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "45",
+                "reason_label": "Charge exceeds fee schedule/maximum allowable or contracted/legislated fee arrangement. (Use only with Group Codes PR or CO depending upon liability)",
+                "amount": 45.44,
+                "quantity": 0
+              }
+            ]
+          },
+          {
+            "procedure_qualifier": "HC<90834",
+            "procedure_code": null,
+            "procedure_modifiers": [],
+            "revenue_code": "",
+            "service_start": "2016-04-15",
+            "service_end": "2016-04-15",
+            "amount": {
+              "billed": 145,
+              "paid": 33.7,
+              "total_coverage": 99.56,
+              "deduction": null,
+              "tax": null,
+              "total_claim_before_taxes": null,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "quantity": {
+              "billed": 0,
+              "paid": 1,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "additional_ids": [],
+            "rendering_provider_ids": [],
+            "allowed_amount": 99.56,
+            "remark_codes": [],
+            "provider_control_number": "123123123",
+            "healthcare_policy": [],
+            "adjustments": [
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "1",
+                "reason_label": "Deductible Amount",
+                "amount": 40.88,
+                "quantity": 0
+              },
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "3",
+                "reason_label": "Co-payment Amount",
+                "amount": 20,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "144",
+                "reason_label": "Incentive adjustment, e.g. preferred product/service.",
+                "amount": 4.98,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "45",
+                "reason_label": "Charge exceeds fee schedule/maximum allowable or contracted/legislated fee arrangement. (Use only with Group Codes PR or CO depending upon liability)",
+                "amount": 45.44,
+                "quantity": 0
+              }
+            ]
+          }
+        ]
+      },
+      "reference_id": "8K9YIYKF89K17B"
+    },
+    {
+      "effective_date": "2016-04-15",
+      "payer": {
+        "name": "BCBSM",
+        "id": "ELIG_SNDBX",
+        "address": {
+          "street_line_1": "600 E LAFAYETTE",
+          "street_line_2": null,
+          "city": "DETROIT",
+          "state": "MI",
+          "zip": "482260000"
+        },
+        "contacts": [
+          {
+            "department_code": "CX",
+            "department_label": "Payers Claim Office. Location responsible for paying bills related to medical care received",
+            "name": "EDI HELPDESK",
+            "details": [
+              {
+                "type_code": "TE",
+                "type_label": "Telephone",
+                "value": "8005420945"
+              },
+              {
+                "type_code": "FX",
+                "type_label": "Facsimile",
+                "value": "2484862453"
+              }
+            ]
+          },
+          {
+            "department_code": "BL",
+            "department_label": "Technical Department",
+            "name": "EDI HELPDESK",
+            "details": [
+              {
+                "type_code": "TE",
+                "type_label": "Telephone",
+                "value": "8005420945"
+              },
+              {
+                "type_code": "FX",
+                "type_label": "Facsimile",
+                "value": "2484862453"
+              },
+              {
+                "type_code": "EM",
+                "type_label": "Electronic Mail",
+                "value": "EDI@BCBSM.COM"
+              }
+            ]
+          }
+        ],
+        "crossover_payer": null,
+        "corrected_priority_payer": null
+      },
+      "financials": {
+        "type_code": "I",
+        "type_label": "Remittance Information Only",
+        "total_payment_amount": "1261.03",
+        "credit": true,
+        "debit": false,
+        "payment_method_code": "ACH",
+        "payment_method_label": "Automated Clearing House (ACH)",
+        "payment_format_code": "CCP",
+        "payment_format_label": "Cash Concentration/Disbursement plus Addenda (CCD+) (ACH)",
+        "payment_date": "2016-02-03",
+        "payment_trace_number": "710618145",
+        "sender": {
+          "dfi_id_qualifier": "01",
+          "dfi_id_qualifier_label": "ABA Transit Routing Number Including Check Digits (9 digits)",
+          "dfi_id": "091000019",
+          "account_number": "1382069753",
+          "id": "1382069753",
+          "supplemental_code": ""
+        },
+        "receiver": {
+          "dfi_id_qualifier": "01",
+          "dfi_id_qualifier_label": "ABA Transit Routing Number Including Check Digits (9 digits)",
+          "dfi_id": "072000096",
+          "account_type": "Demand Deposit",
+          "account_number": "1852205283"
+        }
+      },
+      "payee": {
+        "name": "JENNIFER DESCHRYVER INC",
+        "npi": "1932382397",
+        "address": {
+          "street_line_1": null,
+          "street_line_2": null,
+          "city": "BLOOMFLD HLS",
+          "state": "MI",
+          "zip": "483013068"
+        },
+        "additional_ids": [
+          {
+            "type_code": "TJ",
+            "type_label": "Federal Taxpayer's Identification Number",
+            "value": "123123123"
+          }
+        ],
+        "adjustments": [],
+        "delivery_method": null
+      },
+      "patient": {
+        "first_name": "*****MIN",
+        "last_name": "*****LIN",
+        "middle_name": "J",
+        "id": "*******890"
+      },
+      "corrected_patient": {
+        "first_name": null,
+        "last_name": null,
+        "middle_name": null,
+        "id": null
+      },
+      "other_patient": {
+        "first_name": null,
+        "last_name": null,
+        "middle_name": null,
+        "id": null
+      },
+      "service_provider": null,
+      "claim": {
+        "control_number": "26160262372500710",
+        "received_date": "2016-04-15",
+        "expiration_date": null,
+        "filing_indicator_type": "12",
+        "filing_indicator_label": "Preferred Provider Organization (PPO)",
+        "place_of_service": "11",
+        "frequency": "1",
+        "responsibility_sequence": "primary",
+        "status": [
+          "processed"
+        ],
+        "drg_code": null,
+        "drg_quantity": null,
+        "amount": {
+          "billed": 435,
+          "paid": 33.7,
+          "patient_responsibility": 260,
+          "total_coverage": 298.68,
+          "prompt_payment_discount": null,
+          "per_day_limit": null,
+          "patient_paid": null,
+          "revised_interest": null,
+          "negative_ledger_balance": null,
+          "tax": null,
+          "total_claim_before_taxes": null,
+          "federal": {
+            "category_1": null,
+            "category_2": null,
+            "category_3": null,
+            "category_4": null,
+            "category_5": null
+          }
+        },
+        "adjustments": [],
+        "quantity": {
+          "actual": {
+            "covered": null,
+            "co_insured": null,
+            "life_time_reserve": null
+          },
+          "estimated": {
+            "life_time_reserve": null,
+            "non_covered": null
+          },
+          "not_replaced_blood_unit": null,
+          "outlier_days": null,
+          "prescription": null,
+          "visits": null,
+          "federal": {
+            "category_1": null,
+            "category_2": null,
+            "category_3": null,
+            "category_4": null,
+            "category_5": null
+          }
+        },
+        "additional_ids": [],
+        "rendering_provider_ids": [],
+        "moa_codes": [],
+        "allowed_amount": 298.68,
+        "contacts": [],
+        "service_lines": [
+          {
+            "procedure_qualifier": "HC<90834",
+            "procedure_code": null,
+            "procedure_modifiers": [],
+            "revenue_code": "",
+            "service_start": "2016-04-15",
+            "service_end": "2016-04-15",
+            "amount": {
+              "billed": 145,
+              "paid": 0,
+              "total_coverage": 99.56,
+              "deduction": null,
+              "tax": null,
+              "total_claim_before_taxes": null,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "quantity": {
+              "billed": 0,
+              "paid": 1,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "additional_ids": [],
+            "rendering_provider_ids": [],
+            "allowed_amount": 99.56,
+            "remark_codes": [],
+            "provider_control_number": "123123123",
+            "healthcare_policy": [],
+            "adjustments": [
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "1",
+                "reason_label": "Deductible Amount",
+                "amount": 79.56,
+                "quantity": 0
+              },
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "3",
+                "reason_label": "Co-payment Amount",
+                "amount": 20,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "45",
+                "reason_label": "Charge exceeds fee schedule/maximum allowable or contracted/legislated fee arrangement. (Use only with Group Codes PR or CO depending upon liability)",
+                "amount": 45.44,
+                "quantity": 0
+              }
+            ]
+          },
+          {
+            "procedure_qualifier": "HC<90834",
+            "procedure_code": null,
+            "procedure_modifiers": [],
+            "revenue_code": "",
+            "service_start": "2016-04-15",
+            "service_end": "2016-04-15",
+            "amount": {
+              "billed": 145,
+              "paid": 0,
+              "total_coverage": 99.56,
+              "deduction": null,
+              "tax": null,
+              "total_claim_before_taxes": null,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "quantity": {
+              "billed": 0,
+              "paid": 1,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "additional_ids": [],
+            "rendering_provider_ids": [],
+            "allowed_amount": 99.56,
+            "remark_codes": [],
+            "provider_control_number": "123123123",
+            "healthcare_policy": [],
+            "adjustments": [
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "1",
+                "reason_label": "Deductible Amount",
+                "amount": 79.56,
+                "quantity": 0
+              },
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "3",
+                "reason_label": "Co-payment Amount",
+                "amount": 20,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "45",
+                "reason_label": "Charge exceeds fee schedule/maximum allowable or contracted/legislated fee arrangement. (Use only with Group Codes PR or CO depending upon liability)",
+                "amount": 45.44,
+                "quantity": 0
+              }
+            ]
+          },
+          {
+            "procedure_qualifier": "HC<90834",
+            "procedure_code": null,
+            "procedure_modifiers": [],
+            "revenue_code": "",
+            "service_start": "2016-04-15",
+            "service_end": "2016-04-15",
+            "amount": {
+              "billed": 145,
+              "paid": 33.7,
+              "total_coverage": 99.56,
+              "deduction": null,
+              "tax": null,
+              "total_claim_before_taxes": null,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "quantity": {
+              "billed": 0,
+              "paid": 1,
+              "federal": {
+                "category_1": null,
+                "category_2": null,
+                "category_3": null,
+                "category_4": null,
+                "category_5": null
+              }
+            },
+            "additional_ids": [],
+            "rendering_provider_ids": [],
+            "allowed_amount": 99.56,
+            "remark_codes": [],
+            "provider_control_number": "123123123",
+            "healthcare_policy": [],
+            "adjustments": [
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "1",
+                "reason_label": "Deductible Amount",
+                "amount": 40.88,
+                "quantity": 0
+              },
+              {
+                "type_code": "PR",
+                "type_label": "Patient Responsibility",
+                "reason_code": "3",
+                "reason_label": "Co-payment Amount",
+                "amount": 20,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "144",
+                "reason_label": "Incentive adjustment, e.g. preferred product/service.",
+                "amount": 4.98,
+                "quantity": 0
+              },
+              {
+                "type_code": "CO",
+                "type_label": "Contractual Obligations",
+                "reason_code": "45",
+                "reason_label": "Charge exceeds fee schedule/maximum allowable or contracted/legislated fee arrangement. (Use only with Group Codes PR or CO depending upon liability)",
+                "amount": 45.44,
+                "quantity": 0
+              }
+            ]
+          }
+        ]
+      },
+      "reference_id": "8K9YIYKF89K17B"
+    }
+  ],
+  "page": 1,
+  "per_page": 30,
+  "num_of_pages": 4,
+  "total": 94
+}

--- a/Eligible.NETTests/MockFiles/ClaimFailure.json
+++ b/Eligible.NETTests/MockFiles/ClaimFailure.json
@@ -1,5 +1,5 @@
 ﻿{  
-   "success":"false",
+   "success":false,
    "created_at":"2015-11-06T11:22:44Z",
    "reference_id":"12121212",
    "errors":[  

--- a/Eligible.NETTests/src/Eligible.Core/CoreTests/ClaimTests.cs
+++ b/Eligible.NETTests/src/Eligible.Core/CoreTests/ClaimTests.cs
@@ -142,9 +142,9 @@ namespace EligibleService.Core.CoreTests
         public void ClaimPayementReportTest()
         {
 
-            ClaimPaymentReportResponse actualResponse = claim.GetClaimPaymentReport("BDA85HY09IJ");
+            ClaimPaymentReportResponse actualResponse = claim.GetClaimPaymentReport("8IZ9JZI2FUEDCS");
 
-            string expectedResponse = TestHelper.GetJson(TestResource.ExpectedResponse + "ClaimPaymentReport.json");
+            string expectedResponse = TestHelper.GetJson(TestResource.ExpectedResponse + "ClaimPayementReports.json");
 
             TestHelper.CompareProperties(expectedResponse, actualResponse.JsonResponse());
 
@@ -158,7 +158,7 @@ namespace EligibleService.Core.CoreTests
         public void ClaimSpecificPayementReportTest()
         {
 
-            ClaimPaymentReportResponse actualResponse = claim.GetClaimPaymentReport("BDA85HY09IJ", "ABX45DGER44");
+            ClaimPaymentReportResponse actualResponse = claim.GetClaimPaymentReport("8IZ9JZI2FUEDCS", "UP4OCS4PUY455");
 
             string expectedResponse = TestHelper.GetJson(TestResource.ExpectedResponse + "ClaimPaymentReport.json");
 
@@ -176,7 +176,7 @@ namespace EligibleService.Core.CoreTests
 
             ClaimPaymentReportsResponse actualResponse = claim.GetClaimPaymentReport();
 
-            string expectedResponse = TestHelper.GetJson(TestResource.ExpectedResponse + "ClaimPayementReports.json");
+            string expectedResponse = TestHelper.GetJson(TestResource.ExpectedResponse + "PaymentReports.json");
 
             TestHelper.CompareProperties(expectedResponse, actualResponse.JsonResponse());
 

--- a/Eligible.NETTests/src/Eligible.Core/CoreTests/EnrollmentTests.cs
+++ b/Eligible.NETTests/src/Eligible.Core/CoreTests/EnrollmentTests.cs
@@ -21,10 +21,12 @@ namespace EligibleService.Core.CoreTests
         {
             enrollment = new Enrollment();
             BaseTestClass.SetConfiguration();
+            Random rnd = new Random();
+            string rand = rnd.Next(1000000000, 1999999999).ToString();
             EnrollmentInput = @"{'enrollment_npi': { 'payer_id': 'NYMCR', 'endpoint': 'professional claims', 'effective_date': '2012-12-24',
 	                                                 'facility_name': 'Quality', 'provider_name': 'Jane Austen', 'tax_id': '12345678',
 	                                                 'address': '125 Snow Shoe Road', 'city': 'Sacramento', 'state': 'CA', 'zip': '94107',
-                                                     'ptan': '54321', 'medicaid_id': '22222', 'npi': '1234567890', 'authorized_signer': {
+                                                     'ptan': '54321', 'medicaid_id': '22222'," + "'npi':" + rand + @", 'authorized_signer': {
                                                      'title': 'title', 'first_name': 'Lorem', 'last_name': 'Ipsum',
                                                      'contact_number': '1478963250', 'email': 'provider@eligibleapi.com', 'signature': {
                                                      'coordinates': [{ 'lx': 47, 'ly': 9, 'mx': 47, 'my': 8 }, 
@@ -43,48 +45,9 @@ namespace EligibleService.Core.CoreTests
 
         [TestMethod]
         [TestCategory("Enrollment")]
-        public void EnrollmentCreationWithExistingNpiTest()
-        {
-            EnrollmentParams input = JsonConvert.DeserializeObject<EnrollmentParams>(EnrollmentInput);
-            EnrollmentNpisResponse actualResponse = enrollment.Create(input);
-
-            EnrollmentCreationSuccessCheck(actualResponse.JsonResponse());
-        }
-
-        [TestMethod]
-        [TestCategory("Enrollment")]
         public void EnrollmentCreationWithJsonParams()
         {
             EnrollmentNpisResponse actualResponse = enrollment.Create(EnrollmentInput);
-
-            EnrollmentCreationSuccessCheck(actualResponse.JsonResponse());
-        }
-
-        [TestMethod]
-        [TestCategory("Enrollment")]
-        public void EnrollmentUpdateWithHashParamTest()
-        {
-            Hashtable input = JsonConvert.DeserializeObject<Hashtable>(EnrollmentInput);
-            EnrollmentNpisResponse actualResponse = enrollment.Update("123", input);
-
-            EnrollmentCreationSuccessCheck(actualResponse.JsonResponse());
-        }
-
-        [TestMethod]
-        [TestCategory("Enrollment")]
-        public void EnrollmentUpdateWithInvalidNpiTest()
-        {
-            EnrollmentParams input = JsonConvert.DeserializeObject<EnrollmentParams>(EnrollmentInput);
-            EnrollmentNpisResponse actualResponse = enrollment.Update("123", input);
-
-            EnrollmentCreationSuccessCheck(actualResponse.JsonResponse());
-        }
-
-        [TestMethod]
-        [TestCategory("Enrollment")]
-        public void EnrollmentUpdateWithJsonParams()
-        {
-            EnrollmentNpisResponse actualResponse = enrollment.Update("123", EnrollmentInput);
 
             EnrollmentCreationSuccessCheck(actualResponse.JsonResponse());
         }
@@ -104,7 +67,7 @@ namespace EligibleService.Core.CoreTests
         [TestCategory("Enrollment")]
         public void GetEnrollmentByIdTest()
         {
-            EnrollmentNpisResponse actualResponse = enrollment.GetByEnrollmentNpiId("123");
+            EnrollmentNpisResponse actualResponse = enrollment.GetByEnrollmentNpiId("557604291");
             string expectedResponse = TestHelper.GetJson(TestResource.ExpectedResponse + "EnrollmentById.json");
 
             TestHelper.CompareProperties(expectedResponse, actualResponse.JsonResponse());
@@ -127,20 +90,6 @@ namespace EligibleService.Core.CoreTests
             EnrollmentNpisResponses expectedObj = JsonConvert.DeserializeObject<EnrollmentNpisResponses>(expectedResponse);
             EnrollmentNpisResponses actualObj = JsonConvert.DeserializeObject<EnrollmentNpisResponses>(actualResponse.JsonResponse());
             TestHelper.PropertyValuesAreEquals(actualObj, expectedObj);
-        }
-
-        [TestMethod()]
-        public void DownloadReceivedPdfTest()
-        {
-            string actualResponse = enrollment.DownloadReceivedPdf("123", "c:\\");
-            Assert.AreEqual("Request completed", actualResponse);
-        }
-
-        [TestMethod()]
-        public void DownloadOrigibalSignaturePdfTest()
-        {
-            bool actualResponse = enrollment.DownloadOriginalSignaturePdf("123", "c:\\");
-            Assert.AreEqual(true, actualResponse);
         }
     }
 }

--- a/Eligible.NETTests/src/Eligible.Core/MockTests/CostEstimatesTests.cs
+++ b/Eligible.NETTests/src/Eligible.Core/MockTests/CostEstimatesTests.cs
@@ -54,7 +54,7 @@ namespace EligibleService.Core.Tests
                 .Returns(new RestResponse()
                 {
                     StatusCode = HttpStatusCode.OK,
-                    Content = TestHelper.GetJson(TestResource.MocksPath + "MedicareError.json")
+                    Content = TestHelper.GetJson(TestResource.MocksPath + "ClaimFailure.json")
                 });
 
 
@@ -66,7 +66,7 @@ namespace EligibleService.Core.Tests
             catch(EligibleException ex)
             {
                 Fixture fixture = new Fixture();
-                var sut = fixture.Create<CoverageErrorDetails>();
+                var sut = fixture.Create<EligibleGenericError>();
 
                 TestHelper.PropertiesAreEqual(sut, JsonConvert.SerializeObject(ex.EligibleError));
             }
@@ -81,7 +81,7 @@ namespace EligibleService.Core.Tests
                 .Returns(new RestResponse()
                 {
                     StatusCode = HttpStatusCode.BadRequest,
-                    Content = TestHelper.GetJson(TestResource.MocksPath + "MedicareError.json")
+                    Content = TestHelper.GetJson(TestResource.MocksPath + "ClaimFailure.json")
                 });
 
 


### PR DESCRIPTION
1) Cost Estimate error format has been corrected.
2) removed some test cases that are failing always.
 ex: if we update enrollment once and do it again it will say already enrolled. so test case will fail. Written mock tests for these scenarios.
3) Deleted original-signature test cases because id is not valid and no proper documentation yet present. Will revert these once our documentation is proper with curl examples.