### PR TITLE
ENG-3312: Json error returning as a message in exception.

### DIFF
--- a/Eligible.NET/src/EligibleService.Core/Claim.cs
+++ b/Eligible.NET/src/EligibleService.Core/Claim.cs
@@ -45,11 +45,11 @@ namespace EligibleService.Core
         public ClaimResponse Create(string jsonParams, RequestOptions options = null)
         {
             response = ExecuteObj.ExecutePostPut(EligibleResources.PathToClaims, jsonParams, SetRequestOptionsObject(options));
-            ClaimResponse formattedResponse = RequestProcess.ResponseValidation<ClaimResponse, EligibleGenericError>(response);
+            ClaimResponse formattedResponse = RequestProcess.SimpleResponseValidation<ClaimResponse>(response);
             
             if (formattedResponse.Success == false)
             {
-                throw new EligibleException("Claim creation failed. Please check EligibleError for more details", formattedResponse);
+                throw new EligibleException(response.Content, formattedResponse);
             }
             else
             {

--- a/Eligible.NET/src/EligibleService.Core/CostEstimates.cs
+++ b/Eligible.NET/src/EligibleService.Core/CostEstimates.cs
@@ -27,7 +27,7 @@ namespace EligibleService.Core
         public CostEstimateMedicareResponse Medicare(Hashtable requiredParams, RequestOptions options = null)
         {
             response = ExecuteObj.Execute(EligibleResources.CostEstimates, SetRequestOptionsObject(options), requiredParams);
-            var formattedResponse = RequestProcess.ResponseValidation<CostEstimateMedicareResponse, EligibleGenericError>(response);
+            var formattedResponse = RequestProcess.ResponseValidation<CostEstimateMedicareResponse, MedicareCostEstimateError>(response);
             formattedResponse.SetJsonResponse(response.Content);
             return formattedResponse;
         }

--- a/Eligible.NET/src/EligibleService.Exceptions/ErrorsStructures/EligibleGenericError.cs
+++ b/Eligible.NET/src/EligibleService.Exceptions/ErrorsStructures/EligibleGenericError.cs
@@ -6,9 +6,6 @@ namespace EligibleService.Exceptions
 {
     public class EligibleGenericError
     {
-        [JsonProperty("eligible_id")]
-        public string EligibleId { get; set; }
-
         [JsonProperty("success")]
         public bool? Success { get; set; }
 
@@ -27,7 +24,15 @@ namespace EligibleService.Exceptions
 
     public class CostEstimateError : EligibleGenericError
     {
+        [JsonProperty("eligible_id")]
+        public string EligibleId { get; set; }
         [JsonProperty("warnings")]
         public Collection<Exceptions.GenericError> Warnings { get; set; }
+    }
+
+    public class MedicareCostEstimateError : EligibleGenericError
+    {
+        [JsonProperty("eligible_id")]
+        public string EligibleId { get; set; }
     }
 }

--- a/Eligible.NETTests/Eligible.NETTests.csproj
+++ b/Eligible.NETTests/Eligible.NETTests.csproj
@@ -115,6 +115,7 @@
     <None Include="ExpectedResponse\AllCustomers.json" />
     <None Include="ExpectedResponse\AllEnrollments.json" />
     <None Include="ExpectedResponse\ClaimAcknowledgements.json" />
+    <None Include="ExpectedResponse\ClaimFailure.json" />
     <None Include="ExpectedResponse\ClaimMultipleAcknowledgements.json" />
     <None Include="ExpectedResponse\ClaimPayementReports.json" />
     <None Include="ExpectedResponse\ClaimPaymentReport.json" />
@@ -139,6 +140,7 @@
     <None Include="ExpectedResponse\StatussesByPayer.json" />
     <None Include="MockFiles\ClaimAcknowledgements.json" />
     <None Include="MockFiles\ClaimFailure.json" />
+    <None Include="MockFiles\ClaimPaymentReportError.json" />
     <None Include="MockFiles\ClaimSuccess.json" />
     <None Include="MockFiles\CostEstimate.json" />
     <None Include="MockFiles\CostEstimateAdditionalPolicyWarning.json" />

--- a/Eligible.NETTests/ExpectedResponse/ClaimFailure.json
+++ b/Eligible.NETTests/ExpectedResponse/ClaimFailure.json
@@ -1,0 +1,11 @@
+﻿{
+	"success": false,
+	"created_at": "2016-07-08T17:20:53Z",
+	"errors": [{
+		"code": "rendering_provider_npi_invalid",
+		"param": "rendering_provider[npi]",
+		"message": "The rendering_provider's NPI must be exactly 10 digits",
+		"expected_value": null
+	}],
+	"reference_id": "8LT5WL4UVSJ3GZ"
+}

--- a/Eligible.NETTests/MockFiles/ClaimPaymentReportError.json
+++ b/Eligible.NETTests/MockFiles/ClaimPaymentReportError.json
@@ -1,0 +1,10 @@
+﻿{
+	"success": false,
+	"created_at": "2016-07-08T11:12:25Z",
+	"errors": [{
+		"code": "reference_id_invalid",
+		"param": "reference_id",
+		"message": "Claim not found for reference_id: invalid_id. Please send a valid reference_id.",
+		"expected_value": null
+	}]
+}

--- a/Eligible.NETTests/src/Eligible.Core/MockTests/ClaimTests.cs
+++ b/Eligible.NETTests/src/Eligible.Core/MockTests/ClaimTests.cs
@@ -213,6 +213,35 @@ namespace EligibleService.Core.Tests
             TestHelper.PropertiesAreEqual(sut, report.JsonResponse());
         }
 
+        [TestMethod]
+        [TestCategory("Claim")]
+        public void ClaimExceptionObjectTest()
+        {
+            restClient.Setup(x => x.ExecutePostPut(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<RequestOptions>(), It.IsAny<Method>()))
+                .Returns(new RestResponse()
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = TestHelper.GetJson(TestResource.ExpectedResponse + "ClaimFailure.json")
+                });
+
+
+            claim.ExecuteObj = restClient.Object;
+
+            try
+            {
+                var calimSuccessResponse = claim.Create(param);
+            }
+            catch (EligibleService.Exceptions.EligibleException ex)
+            {
+                Assert.AreEqual(false, ex.EligibleError.Success);
+                Assert.AreEqual("8LT5WL4UVSJ3GZ", ex.EligibleError.ReferenceId);
+                Assert.AreEqual("rendering_provider_npi_invalid", ex.EligibleError.Errors[0].Code);
+                Assert.AreEqual(null, ex.EligibleError.Errors[0].ExpectedValue);
+                Assert.AreEqual("The rendering_provider's NPI must be exactly 10 digits", ex.EligibleError.Errors[0].Message);
+                Assert.AreEqual("rendering_provider[npi]", ex.EligibleError.Errors[0].Param);
+            }
+        }
+
         /// <summary>
         /// Common steps to test Claim creation
         /// </summary>

--- a/Eligible.NETTests/src/Eligible.Core/MockTests/CostEstimatesTests.cs
+++ b/Eligible.NETTests/src/Eligible.Core/MockTests/CostEstimatesTests.cs
@@ -148,6 +148,7 @@ namespace EligibleService.Core.Tests
                 Assert.AreEqual("service_type_code", ex.EligibleError.Errors[0].Param);
                 Assert.AreEqual(null, ex.EligibleError.Errors[0].ExpectedValue);
                 Assert.AreEqual(false, ex.EligibleError.Success);
+                TestHelper.PropertiesAreEqual(ex.EligibleError, ex.Message);
             }
         }
 
@@ -178,6 +179,7 @@ namespace EligibleService.Core.Tests
                 Assert.AreEqual(null, ex.EligibleError.Warnings[0].Param);
                 Assert.AreEqual(null, ex.EligibleError.Warnings[0].ExpectedValue);
                 Assert.AreEqual(false, ex.EligibleError.Success);
+                TestHelper.PropertiesAreEqual(ex.EligibleError, ex.Message);
             }
         }
 

--- a/Eligible.NETTests/src/Eligible.Core/MockTests/CoverageTests.cs
+++ b/Eligible.NETTests/src/Eligible.Core/MockTests/CoverageTests.cs
@@ -421,6 +421,7 @@ namespace EligibleService.Core.Tests
                 var sut = fixture.Create<CoverageErrorDetails>();
 
                 TestHelper.PropertiesAreEqual(sut, JsonConvert.SerializeObject(ex.EligibleError));
+                TestHelper.PropertiesAreEqual(sut, ex.Message);
             }
         }
 


### PR DESCRIPTION
1) Returning back the eligible error message as it is as a exception message. So that customers can use that JSON error instead of C# error object if they want.
2) CostEstimateMedicare don't have warnings property - created a seperate errorclass.
3) Payment report s don't have eligible_id property -  made changes to existing class.

